### PR TITLE
Use wfExpandUrl to accommodate for non-null ArticlePath settings

### DIFF
--- a/src/Processors/Content/ContentCore.php
+++ b/src/Processors/Content/ContentCore.php
@@ -391,7 +391,7 @@ class ContentCore {
 			$title,
 			'/'
 		);
-		$serverUrl = wfGetServerUrl( null ) . '/' . 'index.php';
+
 		if ( self::$fields['mwfollow'] !== false ) {
 			if ( self::$fields['mwfollow'] === 'true' ) {
 				if ( strpos(
@@ -401,7 +401,7 @@ class ContentCore {
 										$title,
 										'::id::'
 									) === false ) {
-					self::$fields['returnto'] = $serverUrl . '/' . $title;
+					self::$fields['returnto'] = wfExpandUrl($title);
 				}
 			} else {
 				if ( strpos(


### PR DESCRIPTION
The code currently redirects users to server/index.php/pagecreatename. When using a MediaWiki instance which uses /wiki/ as an article path, this may lead to problems. This is fixed by letting MediaWiki generate the full url for you, using wfExpandUrl.