### PR TITLE
Update wsInstance.js: fix for apostrophes in values

### DIFF
--- a/Modules/instances/wsInstance.js
+++ b/Modules/instances/wsInstance.js
@@ -164,7 +164,7 @@ const WsInstance = function (selector, options) {
 						}
 					}
 				} else {
-					let optionSelected = $(select).find('option[value=\'' + values[i].replace("'", "\\\'") + '\']')
+					let optionSelected = $(select).find('option[value=\'' + values[i].replaceAll("'", "\\\'") + '\']')
 					if (optionSelected.length > 0 && values[i] !== '') {
 						optionSelected.prop('selected', 'selected')
 					} else if (optionSelected.length === 0 && $(select).data('inputtype') !== 'ws-select2') {

--- a/Modules/instances/wsInstance.js
+++ b/Modules/instances/wsInstance.js
@@ -164,7 +164,7 @@ const WsInstance = function (selector, options) {
 						}
 					}
 				} else {
-					let optionSelected = $(select).find('option[value=\'' + values[i] + '\']')
+					let optionSelected = $(select).find('option[value="' + values[i] + '"]')
 					if (optionSelected.length > 0 && values[i] !== '') {
 						optionSelected.prop('selected', 'selected')
 					} else if (optionSelected.length === 0 && $(select).data('inputtype') !== 'ws-select2') {

--- a/Modules/instances/wsInstance.js
+++ b/Modules/instances/wsInstance.js
@@ -164,7 +164,7 @@ const WsInstance = function (selector, options) {
 						}
 					}
 				} else {
-					let optionSelected = $(select).find('option[value="' + values[i] + '"]')
+					let optionSelected = $(select).find('option[value=\'' + values[i].replace("'", "\\\'") + '\']')
 					if (optionSelected.length > 0 && values[i] !== '') {
 						optionSelected.prop('selected', 'selected')
 					} else if (optionSelected.length === 0 && $(select).data('inputtype') !== 'ws-select2') {


### PR DESCRIPTION
If a value contains an apostrophe, the current implementation fails with 'Syntax error, unrecognized expression'. This fix prevents the issue by using double quotes around the value. 

I don't think we need to cater for double quotes in values, at least not if the values are returned by the API in the JSON format. If I'm mistaken though and there are exceptions, then something like this should work:

```
let optionSelected = $(select).find('option[value="' + values[i].replaceAll('"', '\\"') + '"]')
```