### PR TITLE
Update TagHooks.php - addModules

### DIFF
--- a/src/Render/TagHooks.php
+++ b/src/Render/TagHooks.php
@@ -754,7 +754,7 @@ class TagHooks {
 		switch ( $fieldType ) {
 			case 'text':
 				if ( isset( $args['mwidentifier'] ) && $args['mwidentifier'] === 'datepicker' ) {
-					$parser->getOutput()->addModules( 'ext.wsForm.datePicker.scripts' );
+					$parser->getOutput()->addModules( [ 'ext.wsForm.datePicker.scripts' ] );
 					$parser->getOutput()->addModuleStyles( 'ext.wsForm.datePicker.styles' );
 				}
 				$preparedArguments = Validate::doSimpleParameters(
@@ -1272,7 +1272,7 @@ class TagHooks {
 				$ret = '';
 				if ( isset( $editor ) && $editor === "ve" ) {
 					if ( ExtensionRegistry::getInstance()->isLoaded( 'VEForAll' ) ) {
-						$parser->getOutput()->addModules( 'ext.veforall.main' );
+						$parser->getOutput()->addModules( [ 'ext.veforall.main' ] );
 						$class .= ' load-editor ';
 						$ret = '<span class="ve-area-wrapper">';
 					}


### PR DESCRIPTION
Log riddled with warnings: 
Use of ParserOutput::addModules with non-array argument was deprecated in MediaWiki 1.38