### PR TITLE
Bugfix/1 43 262

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Visit this documentation page https://www.open-csp.org/DevOps:Doc/FlexForm/2.0/V
 Visit : https://www.open-csp.org/DevOps:Doc/FlexForm
 
 ### Changelog
+* 2.6.2 : Fixed deprecation messages
 * 2.6.1 : Fixed messaging bug with persistent messages
 * 2.6.0 : Added form tag : add-as-job. This will put any EDIT functions into jobs. Updated select2.js. Fixed https://github.com/Open-CSP/FlexForm/issues/77
 * 2.5.0 : Maintenance script for syncing Wiki pages that have forms, for us with $config renderonlyapprovedforms and large wikis

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]",
     "[https://www.wikibase-solutions.com/author/marijn Marijn]"

--- a/src/Core/Sql.php
+++ b/src/Core/Sql.php
@@ -266,7 +266,7 @@ class Sql {
 	 */
 	private static function addPageId( int $pageId, array $hashes, bool $valid = true ): bool {
 		$lb          = MediaWikiServices::getInstance()->getDBLoadBalancer();
-		$dbw         = $lb->getConnectionRef( DB_PRIMARY );
+		$dbw         = $lb->getConnection( DB_PRIMARY );
 		try {
 			foreach ( $hashes as $hash ) {
 				if ( empty( $hash ) ) {
@@ -319,11 +319,8 @@ class Sql {
 	}
 
 	/**
-	$lb          = MediaWikiServices::getInstance()->getDBLoadBalancer();
 	 * @param bool $returnNonApproved
-	$dbr         = $lb->getConnectionRef( DB_REPLICA );
 	 * @param bool $returnAll
-	$select      = [ 'page_id', "count" => 'COUNT(*)' ];
 	 *
 	 * @return array
 	 */
@@ -332,7 +329,7 @@ class Sql {
 		bool $returnAll = false
 	): array {
 		$lb     = MediaWikiServices::getInstance()->getDBLoadBalancer();
-		$dbr    = $lb->getConnectionRef( DB_REPLICA );
+		$dbr    = $lb->getConnection( DB_REPLICA );
 		$select = [ 'page_id', 'valid', "count" => 'COUNT(*)' ];
 		$where 	= [ 'valid' => 1 ];
 		if ( $returnNonApproved ) {

--- a/src/Core/Sql.php
+++ b/src/Core/Sql.php
@@ -3,13 +3,14 @@
 namespace FlexForm\Core;
 
 use DatabaseUpdater;
+use Exception;
 use FlexForm\FlexFormException;
 use FlexForm\Processors\Content\Render;
-use Matrix\Exception;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Storage\EditResult;
 use MediaWiki\User\UserIdentity;
+use MWUnknownContentModelException;
 use WikiPage;
 
 /**
@@ -205,7 +206,7 @@ class Sql {
 				throw new FlexFormException( 'Can\'t save to Database [add]' );
 			}
 		} catch ( Exception $e ) {
-			var_dump( $e->getMessage());
+			var_dump( $e->getMessage() );
 			return false;
 		}
 
@@ -238,6 +239,7 @@ class Sql {
 	 *
 	 * @return bool
 	 * @throws FlexFormException
+	 * @throws MWUnknownContentModelException
 	 */
 	public static function addPageFromId( int $id, bool $valid ): bool {
 		$render = new Render();


### PR DESCRIPTION
PHP Deprecated: Use of Wikimedia\Rdbms\LoadBalancer::getConnectionRef was deprecated in MediaWiki 1.39