### PR TITLE
Update ffHoldTillReady.js

### DIFF
--- a/Modules/ffHoldTillReady.js
+++ b/Modules/ffHoldTillReady.js
@@ -24,7 +24,7 @@ function ffHoldTillReady( method, both = true ) {
 				}, 250 )
 			}
 		} else {
-			if ( window.mw ) {
+			if ( window.mw && window.mw.loader.using ) {
 				if ( isFFInitiated() ) {
 					method();
 				} else {


### PR DESCRIPTION
Guard against error `mw.loader.using is not a function`. See #78 for details.
