### PR TITLE
Feature/expand pandoc

### DIFF
--- a/Modules/ext.WSForm.css
+++ b/Modules/ext.WSForm.css
@@ -1,4 +1,7 @@
 
+
+
+
 /* Instances with label inside input fields CSS */
 
 .ff-instance-edit {
@@ -69,7 +72,7 @@ form:has(.flex-form-spinner.active) {
 	isolation: isolate;
 }
 
-form:has(.flex-form-spinner.active)::before {
+form:has(.flex-form-spinner.active)::after {
 	content: "";
 	position: absolute;
 	top: 0;
@@ -81,49 +84,51 @@ form:has(.flex-form-spinner.active)::before {
 	border-radius: inherit;
 }
 
+form:has(.flex-form-spinner.active)::before {
+	content: "";
+	position: absolute;
+	inset: 0 35% 70%;
+	border-radius: 50%;
+	filter: blur(15px);
+}
+
 .flex-form-spinner.active {
 	display: block;
 	position: absolute;
 	top: 50%;
 	left: 50%;
 	z-index: 9999;
-	box-sizing: border-box;
-	width: 80px;
-	height: 80px;
+	width: 15px;
+	height: 15px;
 	border-radius: 50%;
-	border: 4px solid var(--ff-spinner-base, rgba(0, 0, 0, 0.1));
-	transform-origin: 50% 50%;
-	transform: translate(-50%, -50%) perspective(200px) rotateX(66deg);
+	margin-top: -7.5px;
+	margin-left: -7.5px;
+	border: none;
+	animation: ff-dots 1s infinite linear alternate;
 }
 
 .flex-form-spinner.active::before,
 .flex-form-spinner.active::after {
-	content: "";
-	position: absolute;
-	inset: -4px;
-	border-radius: 50%;
-	box-sizing: border-box;
-	border: 4px solid transparent;
-	animation: spinner-spin 1.2s cubic-bezier(0.6, 0.2, 0, 0.8) infinite,
-	spinner-fade 1.2s linear infinite;
+	display: none !important;
 }
 
-.flex-form-spinner.active::before {
-	border-top-color: var(--ff-spinner-color-1, #555);
-}
-
-.flex-form-spinner.active::after {
-	border-top-color: var(--ff-spinner-color-2, #ff3d00);
-	animation-delay: 0.4s;
-}
-
-@keyframes spinner-spin {
-	100% { transform: rotate(360deg); }
-}
-
-@keyframes spinner-fade {
-	25%, 75% { opacity: 0.1; }
-	50% { opacity: 1; }
+@keyframes ff-dots {
+	0%  {
+		box-shadow: 20px 0 var(--ff-spinner-color, #444), -20px 0 rgba(68, 68, 68, 0.2);
+		background: var(--ff-spinner-color, #444);
+	}
+	33% {
+		box-shadow: 20px 0 var(--ff-spinner-color, #444), -20px 0 rgba(68, 68, 68, 0.2);
+		background: rgba(68, 68, 68, 0.2);
+	}
+	66% {
+		box-shadow: 20px 0 rgba(68, 68, 68, 0.2), -20px 0 var(--ff-spinner-color, #444);
+		background: rgba(68, 68, 68, 0.2);
+	}
+	100%{
+		box-shadow: 20px 0 rgba(68, 68, 68, 0.2), -20px 0 var(--ff-spinner-color, #444);
+		background: var(--ff-spinner-color, #444);
+	}
 }
 
 .flex-form-special-top {

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Visit this documentation page https://www.open-csp.org/DevOps:Doc/FlexForm/2.0/V
 Visit : https://www.open-csp.org/DevOps:Doc/FlexForm
 
 ### Changelog
+* 2.8.0 : Pandoc conversions expanded. See online documentation
 * 2.7.2 : Changed submitting of Forms to a better viewable submit status. Introducing --ff-overlay-bg, --ff-spinner-base, --ff-spinner-color-1 and --ff-spinner-color-2 css variables to control colors.
 * 2.7.1 : Added: action=FlexFormOpen&ffAction=canUserBeCreated&additionalData=Harry (example) to check if a user can exist. Added use_mediawiki_mail_settings config setting.
 * 2.7.0 : Fixed Pandoc namespace issue. Rewrote Token SMW Ask query. Added Pandoc prefix and suffix options. Allowing to add prefix- or suffix text to a converted document before it is saved.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "ezyang/htmlpurifier": "4.19.*",
     "phpoffice/phpspreadsheet": "1.30.*",
     "galbar/jsonpath": "^2.1",
-    "designburo/php-pandoc": "~1.0",
+    "designburo/php-pandoc": "*",
     "phpmailer/phpmailer": "^6.8.0",
     "php": ">=8.1 < 9.0",
     "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "ezyang/htmlpurifier": "4.19.*",
     "phpoffice/phpspreadsheet": "1.30.*",
     "galbar/jsonpath": "^2.1",
-    "designburo/pandoc-php": "~1.0",
+    "designburo/php-pandoc": "~1.0",
     "phpmailer/phpmailer": "^6.8.0",
     "php": ">=8.1 < 9.0",
     "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "ezyang/htmlpurifier": "4.19.*",
     "phpoffice/phpspreadsheet": "1.30.*",
     "galbar/jsonpath": "^2.1",
-    "ryakad/pandoc-php": "~1.0",
+    "designburo/pandoc-php": "~1.0",
     "phpmailer/phpmailer": "^6.8.0",
     "php": ">=8.1 < 9.0",
     "ext-json": "*",

--- a/extension.json
+++ b/extension.json
@@ -92,6 +92,7 @@
       "pandoc-install-path" : "",
       "pandoc-convert-from" : [ "docx" ],
       "pandoc-convert-to" : [ "mediawiki" ],
+      "pandoc-allow-additional-arguments" : false,
       "forceNullEdit" : true,
       "allowFlexFormOpenAPI" : false
     }

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.8.0BUILD15",
+  "version": "2.8.0BUILD16",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]",
     "[https://www.wikibase-solutions.com/author/marijn Marijn]"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.8.0BUILD13",
+  "version": "2.8.0BUILD14",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]",
     "[https://www.wikibase-solutions.com/author/marijn Marijn]"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.7.2",
+  "version": "2.7.2BUILD13",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]",
     "[https://www.wikibase-solutions.com/author/marijn Marijn]"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.8.0BUILD18",
+  "version": "2.8.0BUILD19",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]"
   ],

--- a/extension.json
+++ b/extension.json
@@ -1,9 +1,8 @@
 {
   "name": "FlexForm",
-  "version": "2.8.0BUILD16",
+  "version": "2.8.0BUILD17",
   "author": [
-    "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]",
-    "[https://www.wikibase-solutions.com/author/marijn Marijn]"
+    "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]"
   ],
   "url": "https://www.mediawiki.org/wiki/Extension:FlexForm",
   "descriptionmsg": "flexform-desc",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.8.0BUILD14",
+  "version": "2.8.0BUILD15",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]",
     "[https://www.wikibase-solutions.com/author/marijn Marijn]"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.8.0BUILD19",
+  "version": "2.8.0",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]"
   ],

--- a/extension.json
+++ b/extension.json
@@ -90,6 +90,8 @@
       "allowedGroups" : [ "sysop" ],
       "hideEdit" : true,
       "pandoc-install-path" : "",
+      "pandoc-convert-from" : [ "docx" ],
+      "pandoc-convert-to" : [ "mediawiki" ],
       "forceNullEdit" : true,
       "allowFlexFormOpenAPI" : false
     }

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.7.2BUILD13",
+  "version": "2.8.0BUILD13",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]",
     "[https://www.wikibase-solutions.com/author/marijn Marijn]"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.8.0BUILD17",
+  "version": "2.8.0BUILD18",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]"
   ],
@@ -91,7 +91,7 @@
       "pandoc-install-path" : "",
       "pandoc-convert-from" : [ "docx" ],
       "pandoc-convert-to" : [ "mediawiki" ],
-      "pandoc-allow-additional-arguments" : false,
+      "pandoc-allow-additional-arguments" : ["lua-filter"],
       "forceNullEdit" : true,
       "allowFlexFormOpenAPI" : false
     }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -63,6 +63,8 @@
 	"flexform-fileupload-file-title-invalid" : "{$1} could not be imported; a valid title cannot be produced",
 	"flexform-fileupload-no-target" : "No FilePage Title name found (target)",
 	"flexform-fileupload-file-errors" : "We have found errors with the uploaded files : $1",
+	"flexform-fileupload-file-convert-from-error" : "$1 is not set as an allowed convert-from in the local settings",
+	"flexform-fileupload-file-convert-to-error" : "$1 is not set as an allowed convert-to in the local settings",
 	"flexform-fileupload-file-convert-error" : "Error while converting file from $1 to $2",
 	"flexform-fileupload-file-convert-excel-not-found" : "Cannot find Excel sheet.",
 	"flexform-fileupload-file-convert-no-excel-convertor" : "Please run composer to install excel converter",

--- a/src/Processors/Convert/PandocConverter.php
+++ b/src/Processors/Convert/PandocConverter.php
@@ -29,6 +29,11 @@ class PandocConverter extends Convert {
 	private string $convertTo;
 
 	/**
+	 * @var array
+	 */
+	private array $pandocAdditionalArguments = [];
+
+	/**
 	 * @var string
 	 */
 	private string $pandocPathAdditions = '';
@@ -77,8 +82,24 @@ class PandocConverter extends Convert {
 	 *
 	 * @return void
 	 */
-	public function setConvertFrom( string $from ) {
+	public function setConvertFrom( string $from ): void {
 		$this->convertFrom = $from;
+	}
+
+	/**
+	 * @param array $arguments
+	 *
+	 * @return void
+	 */
+	public function setAdditionalArguments( array $arguments ): void {
+		global $IP;
+		$path = $IP . '/';
+		if ( !empty( $arguments ) ) {
+			foreach ( $arguments as $k => $argument ) {
+				$arguments[ $k ] = str_replace( '[path]', $path, $argument );
+			}
+		}
+		$this->pandocAdditionalArguments = $arguments;
 	}
 
 	/**
@@ -86,7 +107,7 @@ class PandocConverter extends Convert {
 	 *
 	 * @return void
 	 */
-	public function setConvertTo( string $from ) {
+	public function setConvertTo( string $from ): void {
 		$this->convertTo = $from;
 	}
 
@@ -141,6 +162,8 @@ class PandocConverter extends Convert {
 			'to'            => $this->convertTo,
 			'extract-media' => $this->getPandocMediaPath()
 		];
+		$options = array_merge( $options, $this->pandocAdditionalArguments );
+		Debug::addToDebug( 'Pandoc Conversion options', $options );
 		try {
 			$wiki = $pandoc->runWith( $this->getFile(), $options );
 		} catch ( PandocException $e ) {

--- a/src/Processors/Convert/PandocConverter.php
+++ b/src/Processors/Convert/PandocConverter.php
@@ -26,6 +26,11 @@ class PandocConverter extends Convert {
 	/**
 	 * @var string
 	 */
+	private string $convertTo;
+
+	/**
+	 * @var string
+	 */
 	private string $pandocPathAdditions = '';
 
 	/**
@@ -66,6 +71,15 @@ class PandocConverter extends Convert {
 	}
 
 	/**
+	 * @param string $from
+	 *
+	 * @return void
+	 */
+	public function setConvertTo( string $from ) {
+		$this->convertTo = $from;
+	}
+
+	/**
 	 * @return string
 	 * @throws FlexFormException
 	 */
@@ -83,10 +97,14 @@ class PandocConverter extends Convert {
 			);
 		}
 
+		if ( $this->convertTo === null ) {
+			$this->convertTo = 'mediawiki';
+		}
+
 		$pandoc  = $this->giveMePandoc();
 		$options = [
 			'from'          => $this->convertFrom,
-			'to'            => 'mediawiki',
+			'to'            => $this->convertTo,
 			'extract-media' => $this->getPandocMediaPath()
 		];
 		try {

--- a/src/Processors/Convert/PandocConverter.php
+++ b/src/Processors/Convert/PandocConverter.php
@@ -34,6 +34,17 @@ class PandocConverter extends Convert {
 	private string $pandocPathAdditions = '';
 
 	/**
+	 * @var array|string[]
+	 */
+	private array $binaryFormats = [
+		"pdf",
+		"docx",
+		"docbook",
+		"docbook5",
+		"pptx"
+	];
+
+	/**
 	 * @return string
 	 */
 	private function getPandocMediaPath(): string {
@@ -80,6 +91,13 @@ class PandocConverter extends Convert {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function isBinaryTarget(): bool {
+		return in_array( strtolower( $this->convertTo ), $this->binaryFormats );
+	}
+
+	/**
 	 * @return string
 	 * @throws FlexFormException
 	 */
@@ -99,6 +117,22 @@ class PandocConverter extends Convert {
 
 		if ( $this->convertTo === null ) {
 			$this->convertTo = 'mediawiki';
+		}
+
+		$allowedFrom = Config::getConfigVariable( 'pandoc-convert-from' );
+		$allowedTo = Config::getConfigVariable( 'pandoc-convert-to' );
+
+		if ( !in_array( strtolower( $this->convertFrom ), $allowedFrom, true ) ) {
+			throw new FlexFormException(
+				wfMessage( 'flexform-fileupload-file-convert-from-error', $this->convertFrom )->parse(),
+				0
+			);
+		}
+		if ( !in_array( strtolower( $this->convertTo ), $allowedTo, true ) ) {
+			throw new FlexFormException(
+				wfMessage( 'flexform-fileupload-file-convert-to-error', $this->convertFrom )->parse(),
+				0
+			);
 		}
 
 		$pandoc  = $this->giveMePandoc();
@@ -122,8 +156,9 @@ class PandocConverter extends Convert {
 				$e
 			);
 		}
-
-		$this->cleanConvertedText( $wiki );
+		if ( !$this->isBinaryTarget() ) {
+			$this->cleanConvertedText( $wiki );
+		}
 
 		return $wiki;
 	}

--- a/src/Processors/Convert/PandocConverter.php
+++ b/src/Processors/Convert/PandocConverter.php
@@ -46,7 +46,9 @@ class PandocConverter extends Convert {
 		"docx",
 		"docbook",
 		"docbook5",
-		"pptx"
+		"pptx",
+		"epub",
+		"odt"
 	];
 
 	/**

--- a/src/Processors/Convert/PandocUploadHandler.php
+++ b/src/Processors/Convert/PandocUploadHandler.php
@@ -51,6 +51,7 @@ class PandocUploadHandler {
 	 * @param string $uploadDir
 	 *
 	 * @throws FlexFormException
+	 * @throws MWContentSerializationException
 	 */
 	public function process(
 		array $convertDetails,

--- a/src/Processors/Convert/PandocUploadHandler.php
+++ b/src/Processors/Convert/PandocUploadHandler.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace FlexForm\Processors\Convert;
+
+use Exception;
+use FlexForm\Core\Config;
+use FlexForm\Core\Debug;
+use FlexForm\FlexFormException;
+use FlexForm\Processors\Content\Save;
+use FlexForm\Processors\Files\FilesCore;
+use FlexForm\Processors\Files\Upload;
+use MediaWiki\MediaWikiServices;
+use MWContentSerializationException;
+use User;
+
+class PandocUploadHandler {
+
+	/**
+	 * @var Upload
+	 */
+	private Upload $uploadProcessor;
+
+	/**
+	 * @var FilesCore
+	 */
+	private FilesCore $filesCore;
+
+	/**
+	 * @param Upload $uploadProcessor
+	 * @param FilesCore $filesCore
+	 */
+	public function __construct( Upload $uploadProcessor, FilesCore $filesCore ) {
+		$this->uploadProcessor = $uploadProcessor;
+		$this->filesCore       = $filesCore;
+	}
+
+	/**
+	 * Executes the Pandoc conversion and handles wiki uploads.
+	 *
+	 * @param array $convertDetails
+	 * @param string $storedFile
+	 * @param string $targetFile
+	 * @param string $titleName
+	 * @param string $fileNameExtension
+	 * @param string $pageContentPrefix
+	 * @param string $pageContentSuffix
+	 * @param string $fileSlot
+	 * @param string $details
+	 * @param string $imageComment
+	 * @param User $user
+	 * @param string $uploadDir
+	 *
+	 * @throws FlexFormException
+	 */
+	public function process(
+		array $convertDetails,
+		string $storedFile,
+		string $targetFile,
+		string $titleName,
+		string $fileNameExtension,
+		string $pageContentPrefix,
+		string $pageContentSuffix,
+		string $fileSlot,
+		string $details,
+		string $imageComment,
+		User $user,
+		string $uploadDir
+	): void {
+		$convert = new PandocConverter();
+		$convert->setConvertFrom( $convertDetails['convertfrom'] );
+		$convert->setConvertTo( $convertDetails['convertto'] );
+		$convert->setAdditionalArguments( $convertDetails['additional-arguments'] );
+		$convert->setFileName(
+			$this->filesCore->parseTarget( $storedFile, $convertDetails['uploadoriginalas'] )
+		);
+
+		$newContent = $convert->convertFile();
+
+		Debug::addToDebug(
+			'File converted with Pandoc: ' . $titleName,
+			[
+				'$pageContentPrefix' => $pageContentPrefix,
+				'$newContent'        => $newContent,
+				'$pageContentSuffix' => $pageContentSuffix
+			]
+		);
+
+		if ( !$convert->isBinaryTarget() ) {
+			$newContent = $pageContentPrefix . $newContent . $pageContentSuffix;
+			$this->processExtractedImages( $convert, $titleName, $user, $imageComment, $details, $newContent );
+
+			// Save the resulting text page
+			$save = new Save();
+			try {
+				$save->saveToWiki(
+					$titleName,
+					[ $fileSlot => $newContent ],
+					$imageComment
+				);
+			} catch ( FlexFormException $e ) {
+				throw new FlexFormException( $e->getMessage(), 0, $e );
+			}
+		} else {
+			// Binary target upload
+			$titleName .= "." . $fileNameExtension;
+			$resultFileUpload = $this->uploadProcessor->uploadFileToWiki(
+				$uploadDir . $storedFile,
+				$titleName,
+				$user,
+				$details,
+				$imageComment,
+				wfTimestampNow()
+			);
+
+			if ( $resultFileUpload !== true ) {
+				throw new FlexFormException( (string)$resultFileUpload, 0 );
+			}
+		}
+
+		// Handle uploadoriginalas logic
+		if ( $convertDetails['uploadoriginalas'] !== "false" ) {
+			$this->processOriginalUpload(
+				$convertDetails, $targetFile, $titleName, $storedFile,
+				$newContent, $details, $imageComment, $user, $uploadDir
+			);
+		}
+	}
+
+	/**
+	 * Helper to process images extracted from the Pandoc conversion.
+	 *
+	 * @param PandocConverter $convert
+	 * @param string $titleName
+	 * @param User $user
+	 * @param string $imageComment
+	 * @param string $details
+	 * @param string $newContent
+	 *
+	 * @return void
+	 * @throws FlexFormException
+	 * @throws MWContentSerializationException
+	 * @throws Exception
+	 */
+	private function processExtractedImages(
+		PandocConverter $convert, string $titleName, User $user,
+		string $imageComment, string $details, string &$newContent
+	): void {
+		$possibleImages = $convert->getPossibleImagesFromConversion();
+		if ( $possibleImages === false ) {
+			return;
+		}
+
+		$fCount = 1;
+		foreach ( $possibleImages as $singleImage ) {
+			$newFname = $titleName . '-' . basename( $singleImage );
+
+			if ( Config::isDebug() ) {
+				Debug::addToDebug(
+					$fCount . ' - Preparing to upload image file from document',
+					[
+						'$newFname'    => $newFname,
+						'$singleImage' => $singleImage,
+						'details'      => $details,
+						'comment'      => $imageComment
+					]
+				);
+			} else {
+				$resultFileUpload = $this->uploadProcessor->uploadFileToWiki(
+					$singleImage, $newFname, $user, $details, $imageComment, wfTimestampNow()
+				);
+
+				if ( $resultFileUpload !== true ) {
+					throw new FlexFormException( (string)$resultFileUpload, 0 );
+				}
+			}
+
+			$search     = $convert->pandocGetSearchFor() . basename( $singleImage );
+			$replace    = $convert->pandocGetReplaceWith( $newFname );
+			$newContent = str_replace( $search, $replace, $newContent );
+
+			unlink( $singleImage );
+			$fCount++;
+		}
+	}
+
+	/**
+	 *
+	 * Helper to process the original file upload if requested.
+	 *
+	 * @param array $convertDetails
+	 * @param string $targetFile
+	 * @param string $titleName
+	 * @param string $storedFile
+	 * @param string $newContent
+	 * @param string $details
+	 * @param string $imageComment
+	 * @param User $user
+	 * @param string $uploadDir
+	 *
+	 * @return void
+	 * @throws FlexFormException
+	 * @throws MWContentSerializationException
+	 * @throws \MWException
+	 */
+	private function processOriginalUpload(
+		array $convertDetails, string $targetFile, string $titleName, string $storedFile,
+		string $newContent, string $details, string $imageComment, User $user, string $uploadDir
+	): void {
+		$uploadOriginalAs = $this->filesCore->parseTarget(
+			$convertDetails['uploadoriginalas'],
+			$targetFile
+		);
+
+		Debug::addToDebug( 'Pandoc Upload Original - parse [filename]', [
+			'targetfile'                           => $targetFile,
+			'uploadoriginalas original'            => $convertDetails['uploadoriginalas'],
+			'after [filename] in targetfile parse' => $uploadOriginalAs
+		] );
+
+		$isOriginalTargetAFile = $this->isFileNameSpace( $titleName );
+		$pTitleName            = $this->checkTitleForTarget( $titleName, $uploadOriginalAs );
+
+		Debug::addToDebug( 'Pandoc Upload Original - parse [target]', [
+			'titleName'                         => $titleName,
+			'after [filename] in targetfile parse' => $uploadOriginalAs,
+			'after [target] in titlename parse'   => $pTitleName,
+		] );
+
+		if ( $convertDetails['original-file-content'] !== "false" ) {
+			$details = $convertDetails['original-file-content'];
+		}
+
+		if ( $isOriginalTargetAFile && empty( $details ) ) {
+			Debug::addToDebug(
+				'Pandoc Upload Original - same title',
+				'Converted title same as uploadoriginal title, content is for main slot, so adding to file-upload'
+			);
+			$details = $newContent;
+		}
+
+		$resultFileUpload = $this->uploadProcessor->uploadFileToWiki(
+			$uploadDir . $storedFile,
+			$pTitleName,
+			$user,
+			$details,
+			$imageComment,
+			wfTimestampNow()
+		);
+
+		if ( $resultFileUpload !== true ) {
+			throw new FlexFormException( (string)$resultFileUpload, 0 );
+		}
+	}
+
+	/**
+	 * @param string $title
+	 * @return bool
+	 */
+	private function isFileNameSpace( string $title ): bool {
+		$titleObject = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $title );
+		return $titleObject !== null && $titleObject->getNamespace() === NS_FILE;
+	}
+
+	/**
+	 * @param string $pageTargetName
+	 * @param string $target
+	 * @return string
+	 */
+	private function checkTitleForTarget( string $pageTargetName, string $target ): string {
+		$target = str_replace( '[target]', $pageTargetName, $target );
+		if ( $this->isFileNameSpace( $target ) ) {
+			$titleObject = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $target );
+			if ( $titleObject !== null ) {
+				$target = $titleObject->getBaseText();
+			}
+		}
+		return $target;
+	}
+}

--- a/src/Processors/Convert/SpreadsheetUploadHandler.php
+++ b/src/Processors/Convert/SpreadsheetUploadHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace FlexForm\Processors\Convert;
+
+use FlexForm\Core\Config;
+use FlexForm\FlexFormException;
+use FlexForm\Processors\Content\Save;
+use FlexForm\Processors\Utilities\General;
+use MWContentSerializationException;
+
+class SpreadsheetUploadHandler {
+
+	/**
+	 * Executes the Spreadsheet conversion and saves the JSON to the wiki.
+	 *
+	 * @param string $fileAction The reader type (e.g., 'xls' or 'xlsx')
+	 * @param string $storedFile The temporary file on disk
+	 * @param string $titleName The target title in the wiki
+	 * @param array $fileDetails The array containing form options
+	 * @param string $imageComment The summary/comment for the edit
+	 *
+	 * @throws FlexFormException|MWContentSerializationException
+	 */
+	public function process(
+		string $fileAction,
+		string $storedFile,
+		string $titleName,
+		array $fileDetails,
+		string $imageComment
+	): void {
+		$excelSheetByName = General::getJsonValue( 'wsform_sheetbyname', $fileDetails );
+		$excelSheetById   = General::getJsonValue( 'wsform_sheetbyid', $fileDetails );
+
+		if ( $excelSheetByName === false && $excelSheetById === false ) {
+			$excelSheetById = 0;
+		}
+
+		$fileSlot = General::getJsonValue( 'wsform_slot', $fileDetails );
+		if ( $fileSlot === false ) {
+			$fileSlot = 'main';
+		}
+
+		$convert = new SpreadsheetConverter();
+		$convert->setReader( $fileAction );
+		$convert->setFileName( $storedFile );
+		$convert->setSheetByName( $excelSheetByName );
+		$convert->setSheetById( $excelSheetById );
+
+		$json = $convert->convertFile();
+
+		// Now create the page in the wiki
+		if ( !Config::isDebug() ) {
+			$save = new Save();
+			try {
+				$save->saveToWiki(
+					$titleName,
+					[ $fileSlot => $json ],
+					$imageComment
+				);
+			} catch ( FlexFormException $e ) {
+				throw new FlexFormException( $e->getMessage(), 0, $e );
+			}
+		}
+	}
+}

--- a/src/Processors/Files/FileUploadOptions.php
+++ b/src/Processors/Files/FileUploadOptions.php
@@ -10,47 +10,47 @@ class FileUploadOptions {
 	/**
 	 * @var mixed
 	 */
-	public mixed $target;
+	public readonly mixed $target;
 
 	/**
 	 * @var mixed
 	 */
-	public mixed $pageContent;
+	public readonly mixed $pageContent;
 
 	/**
 	 * @var mixed
 	 */
-	public mixed $pageContentPrefix;
+	public readonly mixed $pageContentPrefix;
 
 	/**
 	 * @var mixed
 	 */
-	public string|bool $pageContentSuffix;
+	public readonly string|bool $pageContentSuffix;
 
 	/**
 	 * @var mixed
 	 */
-	public mixed $pageTemplate;
+	public readonly mixed $pageTemplate;
 
 	/**
 	 * @var mixed
 	 */
-	public mixed $parseContent;
+	public readonly mixed $parseContent;
 
 	/**
 	 * @var mixed
 	 */
-	public mixed $imageForce;
+	public readonly mixed $imageForce;
 
 	/**
 	 * @var mixed
 	 */
-	public mixed $imageComment;
+	public readonly mixed $imageComment;
 
 	/**
 	 * @var mixed
 	 */
-	public mixed $fileAction;
+	public readonly mixed $fileAction;
 
 	/**
 	 * @param array $fileDetails

--- a/src/Processors/Files/FileUploadOptions.php
+++ b/src/Processors/Files/FileUploadOptions.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace FlexForm\Processors\Files;
+
+use FlexForm\Processors\Utilities\General;
+
+
+class FileUploadOptions {
+
+	/**
+	 * @var mixed
+	 */
+	public mixed $target;
+
+	/**
+	 * @var mixed
+	 */
+	public mixed $pageContent;
+
+	/**
+	 * @var mixed
+	 */
+	public mixed $pageContentPrefix;
+
+	/**
+	 * @var mixed
+	 */
+	public string|bool $pageContentSuffix;
+
+	/**
+	 * @var mixed
+	 */
+	public mixed $pageTemplate;
+
+	/**
+	 * @var mixed
+	 */
+	public mixed $parseContent;
+
+	/**
+	 * @var mixed
+	 */
+	public mixed $imageForce;
+
+	/**
+	 * @var mixed
+	 */
+	public mixed $imageComment;
+
+	/**
+	 * @var mixed
+	 */
+	public mixed $fileAction;
+
+	/**
+	 * @param array $fileDetails
+	 */
+	public function __construct( array $fileDetails ) {
+		$this->target            = General::getJsonValue( 'wsform_file_target', $fileDetails );
+		$this->pageContent       = General::getJsonValue( 'wsform_page_content', $fileDetails );
+		$this->pageContentPrefix = General::getJsonValue( 'wsform_pandoc_prefix', $fileDetails );
+		$this->pageContentSuffix = General::getJsonValue( 'wsform_pandoc_suffix', $fileDetails );
+		$this->pageTemplate      = General::getJsonValue( 'wsform_file_template', $fileDetails );
+		$this->parseContent      = General::getJsonValue( 'wsform_parse_content', $fileDetails );
+		$this->imageForce        = General::getJsonValue( 'wsform_image_force', $fileDetails );
+		$this->imageComment      = General::getJsonValue( 'wsform-upload-comment', $fileDetails );
+		$this->fileAction        = General::getJsonValue( 'wsform_action', $fileDetails );
+	}
+}

--- a/src/Processors/Files/FilesCore.php
+++ b/src/Processors/Files/FilesCore.php
@@ -163,8 +163,11 @@ class FilesCore {
 	 * @return string
 	 */
 	public function getFileExtension( string $file ) : string {
+		$extension = '';
 		$path_parts = pathinfo( $file );
-		$extension  = $path_parts['extension'];
+		if ( isset( $path_parts['extension'] ) ) {
+			$extension = $path_parts['extension'];
+		}
 
 		return strtolower( $extension );
 	}

--- a/src/Processors/Files/FilesCore.php
+++ b/src/Processors/Files/FilesCore.php
@@ -163,13 +163,8 @@ class FilesCore {
 	 * @return string
 	 */
 	public function getFileExtension( string $file ) : string {
-		$extension = '';
-		$path_parts = pathinfo( $file );
-		if ( isset( $path_parts['extension'] ) ) {
-			$extension = $path_parts['extension'];
-		}
-
-		return strtolower( $extension );
+		$pathParts = pathinfo( $file );
+		return strtolower( $pathParts['extension'] ?? '' );
 	}
 
 	/**

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -671,73 +671,73 @@ class Upload {
 						}
 					}
 					// Now create the page in the wiki
-					if ( !Config::isDebug() ) {
-						if ( !$convert->isBinaryTarget() ) {
-							$save = new Save();
-							try {
-								$save->saveToWiki(
-									$titleName,
-									[ $fileSlot => $newContent ],
-									$imageComment
-								);
-							} catch ( FlexFormException $e ) {
-								throw new FlexFormException(
-									$e->getMessage(), 0, $e
-								);
-							}
-						}
-						if ( $fileActionConvertDetails['uploadoriginalas'] !== "false" ) {
-							// Check if [filename] should be replaced
-							$uploadOriginalAs = $filesCore->parseTarget(
-								$fileActionConvertDetails['uploadoriginalas'],
-								$targetFile,
-							);
-							Debug::addToDebug( 'Pandoc Upload Original - parse [filename]',
-								[
-									'targetfile' => $targetFile,
-									'uploadoriginalas original' => $fileActionConvertDetails['uploadoriginalas'],
-									'after [filename] in targetfile parse' => $uploadOriginalAs
-								] );
-							$pTitleName = $this->checkTitleForTarget(
+
+					if ( !$convert->isBinaryTarget() ) {
+						$save = new Save();
+						try {
+							$save->saveToWiki(
 								$titleName,
-								$uploadOriginalAs
+								[ $fileSlot => $newContent ],
+								$imageComment
 							);
-							Debug::addToDebug( 'Pandoc Upload Original - parse [target]',
-							[
-								'titleName' => $titleName,
-								'after [filename] in targetfile parse' => $uploadOriginalAs,
-								'after [target] in titlename parse' => $pTitleName,
-							]
+						} catch ( FlexFormException $e ) {
+							throw new FlexFormException(
+								$e->getMessage(), 0, $e
 							);
-							if ( $fileActionConvertDetails['original-file-content'] !== "false" ) {
-								$details = $fileActionConvertDetails['original-file-content'];
-							}
-							if (
-								$this->isFileNameSpace( $pTitleName )
-								&& empty( $details )
-							) {
-								Debug::addToDebug( 'Pandoc Upload Original - same title',
-									'Converted title same as uploadoriginal title',
-									'content is for main slot, so adding to file-upload'
-								);
-								$details = $newContent;
-							}
-							$resultFileUpload = $this->uploadFileToWiki(
-							$upload_dir . $storedFile,
-							$pTitleName,
-							$thisUser,
-							$details,
-							$imageComment,
-							wfTimestampNow()
-							);
-							if ( $resultFileUpload !== true ) {
-								throw new FlexFormException(
-									$resultFileUpload, 0
-								);
-							}
 						}
 					}
-					break;
+					if ( $fileActionConvertDetails['uploadoriginalas'] !== "false" ) {
+						// Check if [filename] should be replaced
+						$uploadOriginalAs = $filesCore->parseTarget(
+							$fileActionConvertDetails['uploadoriginalas'],
+							$targetFile,
+						);
+						Debug::addToDebug( 'Pandoc Upload Original - parse [filename]',
+							[
+								'targetfile' => $targetFile,
+								'uploadoriginalas original' => $fileActionConvertDetails['uploadoriginalas'],
+								'after [filename] in targetfile parse' => $uploadOriginalAs
+							] );
+						$isOriginalTargetAFile = $this->isFileNameSpace( $titleName );
+						$pTitleName = $this->checkTitleForTarget(
+							$titleName,
+							$uploadOriginalAs
+						);
+						Debug::addToDebug( 'Pandoc Upload Original - parse [target]',
+						[
+							'titleName' => $titleName,
+							'after [filename] in targetfile parse' => $uploadOriginalAs,
+							'after [target] in titlename parse' => $pTitleName,
+						]
+						);
+						if ( $fileActionConvertDetails['original-file-content'] !== "false" ) {
+							$details = $fileActionConvertDetails['original-file-content'];
+						}
+						if (
+							$isOriginalTargetAFile
+							&& empty( $details )
+						) {
+							Debug::addToDebug( 'Pandoc Upload Original - same title',
+								'Converted title same as uploadoriginal title' .
+								'content is for main slot, so adding to file-upload'
+							);
+							$details = $newContent;
+						}
+						$resultFileUpload = $this->uploadFileToWiki(
+						$upload_dir . $storedFile,
+						$pTitleName,
+						$thisUser,
+						$details,
+						$imageComment,
+						wfTimestampNow()
+						);
+						if ( $resultFileUpload !== true ) {
+							throw new FlexFormException(
+								$resultFileUpload, 0
+							);
+						}
+					}
+				break;
 				}
 			} else {
 				if ( !Config::isDebug() ) {
@@ -788,6 +788,7 @@ class Upload {
 	 */
 	private function isFileNameSpace( string $title ): bool {
 		$titleObject = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $title );
+		var_dump ( $title, $titleObject->getNamespace() );
 		if ( $titleObject !== null && $titleObject->getNamespace() === NS_FILE ) {
 			return true;
 		}

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -82,7 +82,9 @@ class Upload {
 		$fileActions = [
 			'convertfrom' => null,
 			'convertto' => 'mediawiki',
-			'uploadoriginalas' => "false" ];
+			'uploadoriginalas' => "false",
+			'additional-arguments' => []
+		];
 
 		if ( str_contains( $action, '|' ) ) {
 			$explodedAction = explode( '|', $action );
@@ -97,10 +99,56 @@ class Upload {
 				}
 			}
 		}
+
+		if ( !empty( $fileActions['additional-arguments'] ) ) {
+			$fileActions['additional-arguments'] = explode( ',', $fileActions['additional-arguments'] );
+			$newArgs = [];
+			foreach ( $fileActions['additional-arguments'] as $singleAdditionalArgument ) {
+				if ( str_contains( $singleAdditionalArgument, '=' ) ) {
+					$explodedArgs = explode( '=', $singleAdditionalArgument );
+					$newArgs[ $explodedArgs[0] ] = $explodedArgs[1];
+				} else {
+					$newArgs[ $singleAdditionalArgument ] = '';
+				}
+			}
+			$fileActions['additional-arguments'] = $newArgs;
+		}
+		Debug::addToDebug( 'Pandoc conversion options', $fileActions );
+		if (
+			$this->checkAllowedConversions(
+				$fileActions['convertfrom'],
+				$fileActions['convertto'],
+				$fileActions['additional-arguments']
+			) === false
+		) {
+			return null;
+		}
 		if ( $fileActions['convertfrom'] === null ) {
 			return null;
 		}
 		return $fileActions;
+	}
+
+	/**
+	 * @param string $from
+	 * @param string $to
+	 * @param array $additional
+	 *
+	 * @return bool
+	 */
+	private function checkAllowedConversions( string $from, string $to, array $additional = [] ) {
+		if ( !in_array( $from, Config::getConfigVariable( 'pandoc-convert-from' ) ) ) {
+			return false;
+		}
+		if ( !in_array( $to, Config::getConfigVariable( 'pandoc-convert-to' ) ) ) {
+			return false;
+		}
+		if ( !empty( $additional ) ) {
+			if ( Config::getConfigVariable( 'pandoc-allow-additional-arguments' ) === false ) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**
@@ -181,7 +229,7 @@ class Upload {
 		);
 		$fileActionConvertDetails = null;
 		if ( $fileAction !== false ) {
-			$fileAction = ContentCore::parseTitle( $fileAction, true );
+			//$fileAction = ContentCore::parseTitle( $fileAction, true );
 			if ( strtolower( $fileAction ) !== 'upload' && !str_contains( strtolower( $fileAction ), 'convertfrom:' ) ) {
 				throw new FlexFormException(
 					'Unknown upload action',
@@ -192,7 +240,18 @@ class Upload {
 				// $fileAction = trim( str_replace( 'convertfrom:', '', strtolower( $fileAction ) ) );
 
 				$fileActionConvertDetails = $this->decodeAction( $fileAction );
-				$fileAction = 'convert';
+				if ( $fileActionConvertDetails !== null ) {
+					$fileAction = 'convert';
+				} else {
+					Debug::addToDebug(
+						'convertfrom error',
+						[
+							'fileaction'       => $fileAction,
+							'fileActionConvertDetails' => $fileActionConvertDetails
+						]
+					);
+				}
+
 			}
 		}
 
@@ -520,10 +579,16 @@ class Upload {
 					break;
 				case "convert":
 					// We need to do a Pandoc conversion
+					//echo "<pre>";
+					//var_dump( $fileActionConvertDetails );
+					//die();
 					$convert = new PandocConverter();
 					$convert->setConvertFrom( $fileActionConvertDetails['convertfrom'] );
 					$convert->setConvertTo( $fileActionConvertDetails['convertto'] );
-					$convert->setFileName( $storedFile );
+					$convert->setAdditionalArguments( $fileActionConvertDetails['additional-arguments'] );
+					$convert->setFileName(
+						$filesCore->parseTarget( $storedFile, $fileActionConvertDetails['uploadoriginalas'] )
+					);
 					$newContent = $convert->convertFile();
 					Debug::addToDebug(
 						'File converted with Pandoc: ' . $titleName,

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -788,7 +788,6 @@ class Upload {
 	 */
 	private function isFileNameSpace( string $title ): bool {
 		$titleObject = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $title );
-		var_dump ( $title, $titleObject->getNamespace() );
 		if ( $titleObject !== null && $titleObject->getNamespace() === NS_FILE ) {
 			return true;
 		}
@@ -803,8 +802,11 @@ class Upload {
 	 */
 	private function checkTitleForTarget( string $pageTargetName, string $target ): string {
 		$target = str_replace( '[target]', $pageTargetName, $target );
-		if ( str_starts_with( $target, 'File:', ) || str_starts_with( $target, 'file:', ) ) {
-			$target = str_replace( [ 'File:', 'file:' ], '', $target );
+		if ( $this->isFileNameSpace( $target ) ) {
+			$titleObject = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $target );
+			if ( $titleObject !== null ) {
+				$target = $titleObject->getBaseText();
+			}
 		}
 		return $target;
 	}

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -114,14 +114,16 @@ class Upload {
 			$fileActions['additional-arguments'] = $newArgs;
 		}
 		Debug::addToDebug( 'Pandoc conversion options', $fileActions );
-		if (
-			$this->checkAllowedConversions(
-				$fileActions['convertfrom'],
-				$fileActions['convertto'],
-				$fileActions['additional-arguments']
-			) === false
-		) {
-			return null;
+		$checkConversions = $this->checkAllowedConversions(
+			$fileActions['convertfrom'],
+			$fileActions['convertto'],
+			$fileActions['additional-arguments']
+		);
+		if ( $checkConversions !== true ) {
+			throw new FlexFormException(
+				'Pandoc Error: ' . $checkConversions,
+				0
+			);
 		}
 		if ( $fileActions['convertfrom'] === null ) {
 			return null;
@@ -134,18 +136,18 @@ class Upload {
 	 * @param string $to
 	 * @param array $additional
 	 *
-	 * @return bool
+	 * @return bool|string
 	 */
-	private function checkAllowedConversions( string $from, string $to, array $additional = [] ) {
+	private function checkAllowedConversions( string $from, string $to, array $additional = [] ): bool|string {
 		if ( !in_array( $from, Config::getConfigVariable( 'pandoc-convert-from' ) ) ) {
-			return false;
+			return "Convert from '$from' is not allowed.";
 		}
 		if ( !in_array( $to, Config::getConfigVariable( 'pandoc-convert-to' ) ) ) {
-			return false;
+			return "Convert to '$to' is not allowed.";
 		}
 		if ( !empty( $additional ) ) {
 			if ( Config::getConfigVariable( 'pandoc-allow-additional-arguments' ) === false ) {
-				return false;
+				return "pandoc-allow-additional-arguments are not allowed.";
 			}
 		}
 		return true;
@@ -229,7 +231,6 @@ class Upload {
 		);
 		$fileActionConvertDetails = null;
 		if ( $fileAction !== false ) {
-			//$fileAction = ContentCore::parseTitle( $fileAction, true );
 			if ( strtolower( $fileAction ) !== 'upload' && !str_contains( strtolower( $fileAction ), 'convertfrom:' ) ) {
 				throw new FlexFormException(
 					'Unknown upload action',
@@ -237,19 +238,22 @@ class Upload {
 				);
 			}
 			if ( str_contains( strtolower( $fileAction ), 'convertfrom:' ) ) {
-				// $fileAction = trim( str_replace( 'convertfrom:', '', strtolower( $fileAction ) ) );
-
 				$fileActionConvertDetails = $this->decodeAction( $fileAction );
 				if ( $fileActionConvertDetails !== null ) {
 					$fileAction = 'convert';
 				} else {
 					Debug::addToDebug(
-						'convertfrom error',
+						'Pandoc convertfrom error',
 						[
 							'fileaction'       => $fileAction,
 							'fileActionConvertDetails' => $fileActionConvertDetails
 						]
 					);
+					throw new FlexFormException(
+						'Pandoc convertfrom error. No convert-from found',
+						0
+					);
+
 				}
 
 			}

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -760,7 +760,11 @@ class Upload {
 	 * @return bool
 	 */
 	private function checkTitleForTarget( string $pageTargetName, $target ): bool {
-		return str_replace( '[target]', $pageTargetName, $target );
+		$target = str_replace( '[target]', $pageTargetName, $target );
+		if ( str_starts_with( $target, 'File:', ) || str_starts_with( $target, 'file:', ) ) {
+			$target = str_replace( [ 'File:', 'file:' ], '', $target );
+		}
+		return $target;
 	}
 
 	/**

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -83,6 +83,7 @@ class Upload {
 			'convertfrom' => null,
 			'convertto' => 'mediawiki',
 			'uploadoriginalas' => "false",
+			'original-file-content' => "false",
 			'additional-arguments' => []
 		];
 
@@ -231,10 +232,12 @@ class Upload {
 		);
 		$fileActionConvertDetails = null;
 		if ( $fileAction !== false ) {
-			if ( strtolower( $fileAction ) !== 'upload' && !str_contains( strtolower( $fileAction ), 'convertfrom:' ) ) {
+			if (
+				strtolower( $fileAction ) !== 'upload' &&
+				!str_contains( strtolower( $fileAction ), 'convertfrom:' )
+			) {
 				throw new FlexFormException(
-					'Unknown upload action',
-					0
+					'Unknown upload action', 0
 				);
 			}
 			if ( str_contains( strtolower( $fileAction ), 'convertfrom:' ) ) {
@@ -694,7 +697,7 @@ class Upload {
 									'targetfile' => $targetFile,
 									'uploadoriginalas original' => $fileActionConvertDetails['uploadoriginalas'],
 									'after [filename] in targetfile parse' => $uploadOriginalAs
-								]);
+								] );
 							$pTitleName = $this->checkTitleForTarget(
 								$titleName,
 								$uploadOriginalAs
@@ -706,6 +709,9 @@ class Upload {
 								'after [target] in titlename parse' => $pTitleName,
 							]
 							);
+							if ( $fileActionConvertDetails['original-file-content'] !== "false" ) {
+								$details = $fileActionConvertDetails['original-file-content'];
+							}
 							if (
 								$this->isFileNameSpace( $pTitleName )
 								&& empty( $details )
@@ -714,7 +720,7 @@ class Upload {
 									'Converted title same as uploadoriginal title',
 									'content is for main slot, so adding to file-upload'
 								);
-								$details = [ $fileSlot => $newContent ];
+								$details = $newContent;
 							}
 							$resultFileUpload = $this->uploadFileToWiki(
 							$upload_dir . $storedFile,

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -602,6 +602,7 @@ class Upload {
 							'$pageContentSuffix'  => $pageContentSuffix
 						]
 					);
+					// If the target is not binary, we can create the page and upload attached files
 					if ( !$convert->isBinaryTarget() ) {
 						$newContent = $pageContentPrefix . $newContent . $pageContentSuffix;
 						$possibleImagesInDocument = $convert->getPossibleImagesFromConversion();
@@ -649,6 +650,7 @@ class Upload {
 							}
 						}
 					} else {
+						// If the target is binary, then simply upload it
 						$titleName .= "." . $fileNameExtension;
 
 						$resultFileUpload = $this->uploadFileToWiki(
@@ -682,17 +684,23 @@ class Upload {
 							}
 						}
 						if ( $fileActionConvertDetails['uploadoriginalas'] !== "false" ) {
-							$pTitleName = $filesCore->parseTarget(
+							// Check if [filename] should be replaced
+							$uploadOriginalAs = $filesCore->parseTarget(
 								$targetFile,
 								$fileActionConvertDetails['uploadoriginalas']
 							);
-								$resultFileUpload = $this->uploadFileToWiki(
-								$upload_dir . $storedFile,
-								$pTitleName,
-								$thisUser,
-								$details,
-								$imageComment,
-								wfTimestampNow()
+							$pTitleName = $this->checkTitleForTarget(
+								$titleName,
+								$uploadOriginalAs
+							);
+
+							$resultFileUpload = $this->uploadFileToWiki(
+							$upload_dir . $storedFile,
+							$pTitleName,
+							$thisUser,
+							$details,
+							$imageComment,
+							wfTimestampNow()
 							);
 							if ( $resultFileUpload !== true ) {
 								throw new FlexFormException(
@@ -743,6 +751,16 @@ class Upload {
 		);
 
 		return true;
+	}
+
+	/**
+	 * @param string $pageTargetName
+	 * @param $target
+	 *
+	 * @return bool
+	 */
+	private function checkTitleForTarget( string $pageTargetName, $target ): bool {
+		return str_replace( '[target]', $pageTargetName, $target );
 	}
 
 	/**

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -158,6 +158,7 @@ class Upload {
 			foreach ( $fileActions['additional-arguments'] as $singleAdditionalArgument ) {
 				if ( str_contains( $singleAdditionalArgument, '=' ) ) {
 					$explodedArgs = explode( '=', $singleAdditionalArgument );
+					if ( $explodedArgs[0] )
 					$newArgs[$explodedArgs[0]] = $explodedArgs[1];
 				} else {
 					$newArgs[$singleAdditionalArgument] = '';
@@ -198,8 +199,10 @@ class Upload {
 			return "Convert to '$to' is not allowed.";
 		}
 		if ( !empty( $additional ) ) {
-			if ( Config::getConfigVariable( 'pandoc-allow-additional-arguments' ) === false ) {
-				return "pandoc-allow-additional-arguments are not allowed.";
+			foreach ( $additional as $singleAdditional ) {
+				if ( !in_array( $singleAdditional, Config::getConfigVariable( 'pandoc-allow-additional-arguments' ) ) ) {
+					return "Additional argument '$singleAdditional' is not allowed.";
+				}
 			}
 		}
 

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -533,88 +533,102 @@ class Upload {
 							'$pageContentSuffix'  => $pageContentSuffix
 						]
 					);
-					$newContent = $pageContentPrefix . $newContent . $pageContentSuffix;
-					$possibleImagesInDocument = $convert->getPossibleImagesFromConversion();
-					if ( $possibleImagesInDocument !== false ) {
-						$fCount = 1;
-						foreach ( $possibleImagesInDocument as $singleImage ) {
-							// find [filename] and replace
-							$newFname = $titleName . '-' . basename( $singleImage );
-							if ( Config::isDebug() ) {
-								Debug::addToDebug(
-									$fCount . ' - Preparing to upload image file from document: ' . $fCount,
-									[
-										'$newFname'    => $newFname,
-										'$singleImage' => $singleImage,
-										'stored file'  => $storedFile,
-										'details'      => $details,
-										'comment'      => $imageComment
-									]
-								);
-							}
-							if ( !Config::isDebug() ) {
-								$resultFileUpload = $this->uploadFileToWiki(
-									$singleImage,
-									$newFname,
-									$thisUser,
-									$details,
-									$imageComment,
-									wfTimestampNow()
-								);
-								if ( $resultFileUpload !== true ) {
-									throw new FlexFormException(
-										$resultFileUpload,
-										0
+					if ( !$convert->isBinaryTarget() ) {
+						$newContent = $pageContentPrefix . $newContent . $pageContentSuffix;
+						$possibleImagesInDocument = $convert->getPossibleImagesFromConversion();
+						if ( $possibleImagesInDocument !== false ) {
+							$fCount = 1;
+							foreach ( $possibleImagesInDocument as $singleImage ) {
+								// find [filename] and replace
+								$newFname = $titleName . '-' . basename( $singleImage );
+								if ( Config::isDebug() ) {
+									Debug::addToDebug(
+										$fCount . ' - Preparing to upload image file from document: ' . $fCount,
+										[
+											'$newFname' => $newFname,
+											'$singleImage' => $singleImage,
+											'stored file' => $storedFile,
+											'details' => $details,
+											'comment' => $imageComment
+										]
 									);
 								}
+								if ( !Config::isDebug() ) {
+									$resultFileUpload = $this->uploadFileToWiki(
+										$singleImage,
+										$newFname,
+										$thisUser,
+										$details,
+										$imageComment,
+										wfTimestampNow()
+									);
+									if ( $resultFileUpload !== true ) {
+										throw new FlexFormException(
+											$resultFileUpload, 0
+										);
+									}
+								}
+								$search = $convert->pandocGetSearchFor() . basename( $singleImage );
+								$replace = $convert->pandocGetReplaceWith( $newFname );
+								$newContent = str_replace(
+									$search,
+									$replace,
+									$newContent
+								);
+								unlink( $singleImage );
+								$fCount++;
 							}
-							$search     = $convert->pandocGetSearchFor() . basename( $singleImage );
-							$replace    = $convert->pandocGetReplaceWith( $newFname );
-							$newContent = str_replace(
-								$search,
-								$replace,
-								$newContent
+						}
+					} else {
+						$titleName .= "." . $fileNameExtension;
+
+						$resultFileUpload = $this->uploadFileToWiki(
+							$upload_dir . $storedFile,
+							$titleName,
+							$thisUser,
+							$details,
+							$imageComment,
+							wfTimestampNow()
+						);
+						if ( $resultFileUpload !== true ) {
+							throw new FlexFormException(
+								$resultFileUpload, 0
 							);
-							unlink( $singleImage );
-							$fCount++;
 						}
 					}
 					// Now create the page in the wiki
 					if ( !Config::isDebug() ) {
-						$save = new Save();
-						try {
-							$save->saveToWiki(
-								$titleName,
-								[ $fileSlot => $newContent ],
-								$imageComment
-							);
-						} catch ( FlexFormException $e ) {
-							throw new FlexFormException(
-								$e->getMessage(),
-								0,
-								$e
-							);
+						if ( !$convert->isBinaryTarget() ) {
+							$save = new Save();
+							try {
+								$save->saveToWiki(
+									$titleName,
+									[ $fileSlot => $newContent ],
+									$imageComment
+								);
+							} catch ( FlexFormException $e ) {
+								throw new FlexFormException(
+									$e->getMessage(), 0, $e
+								);
+							}
 						}
-						if ( $fileActionConvertDetails['uploadoriginalas'] !== "false") {
+						if ( $fileActionConvertDetails['uploadoriginalas'] !== "false" ) {
 							$pTitleName = $filesCore->parseTarget(
 								$targetFile,
 								$fileActionConvertDetails['uploadoriginalas']
 							);
-							if ( ! Config::isDebug() ) {
 								$resultFileUpload = $this->uploadFileToWiki(
-									$upload_dir . $storedFile,
-									$pTitleName,
-									$thisUser,
-									$details,
-									$imageComment,
-									wfTimestampNow()
+								$upload_dir . $storedFile,
+								$pTitleName,
+								$thisUser,
+								$details,
+								$imageComment,
+								wfTimestampNow()
+							);
+							if ( $resultFileUpload !== true ) {
+								throw new FlexFormException(
+									$resultFileUpload, 0
 								);
-								if ( $resultFileUpload !== true ) {
-									throw new FlexFormException(
-										$resultFileUpload,
-										0
-									);
-								}
 							}
 						}
 					}

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -10,20 +10,21 @@
 
 namespace FlexForm\Processors\Files;
 
+use Exception;
 use FlexForm\Core\Config;
 use FlexForm\Core\Debug;
 use FlexForm\FlexFormException;
 use FlexForm\Processors\Content\ContentCore;
 use FlexForm\Processors\Content\Save;
-use FlexForm\Processors\Convert\PandocConverter;
-use FlexForm\Processors\Convert\SpreadsheetConverter;
+use FlexForm\Processors\Convert\PandocUploadHandler;
+use FlexForm\Processors\Convert\SpreadsheetUploadHandler;
 use FlexForm\Processors\Definitions;
 use FlexForm\Processors\Utilities\General;
 use MediaHandler;
+use MWContentSerializationException;
 use MWFileProps;
 use Title;
 use User;
-use Wikimedia\AtEase\AtEase;
 use MediaWiki\MediaWikiServices;
 
 class Upload {
@@ -73,10 +74,53 @@ class Upload {
 		return $this->fileDetails;
 	}
 
+
+	/**
+	 * Validates the file action and extracts Pandoc convert details if applicable.
+	 *
+	 * @param mixed $fileAction
+	 *
+	 * @return array{0: string|bool, 1: array|null} Returns the finalized action and convert details.
+	 * @throws FlexFormException
+	 */
+	private function parseFileAction( mixed $fileAction ): array {
+		$fileActionConvertDetails = null;
+
+		if ( $fileAction === false ) {
+			return [ $fileAction, $fileActionConvertDetails ];
+		}
+
+		$actionLower = strtolower( $fileAction );
+
+		if ( $actionLower !== 'upload' && !str_contains( $actionLower, 'convertfrom:' ) ) {
+			throw new FlexFormException( 'Unknown upload action', 0 );
+		}
+
+		if ( str_contains( $actionLower, 'convertfrom:' ) ) {
+			$fileActionConvertDetails = $this->decodeAction( $fileAction );
+
+			if ( $fileActionConvertDetails !== null ) {
+				$fileAction = 'convert';
+			} else {
+				Debug::addToDebug(
+					'Pandoc convertfrom error',
+					[
+						'fileaction'               => $fileAction,
+						'fileActionConvertDetails' => null
+					]
+				);
+				throw new FlexFormException( 'Pandoc convertfrom error. No convert-from found', 0 );
+			}
+		}
+
+		return [ $fileAction, $fileActionConvertDetails ];
+	}
+
 	/**
 	 * @param string $action
 	 *
 	 * @return string[]|null
+	 * @throws FlexFormException
 	 */
 	private function decodeAction( string $action ): ?array {
 		$fileActions = [
@@ -157,6 +201,8 @@ class Upload {
 	/**
 	 * @return bool
 	 * @throws FlexFormException
+	 * @throws MWContentSerializationException
+	 * @throws \MWException
 	 */
 	public function fileUpload() : bool {
 		/**
@@ -194,6 +240,40 @@ class Upload {
 		}
 
 		$fileToProcess = $_FILES[$fileName];
+
+		$options = new FileUploadOptions( $fileDetails );
+
+		[ $fileAction, $fileActionConvertDetails ] = $this->parseFileAction( $options->fileAction );
+
+		$nrOfFiles = count( $fileToProcess['name'] );
+		if ( Config::isDebug() ) {
+			Debug::addToDebug( 'Number of files to process', $nrOfFiles );
+		}
+
+		$errors    = [];
+		$filesCore = new FilesCore();
+
+		if ( $options->target === false || $options->target === '' ) {
+			throw new FlexFormException( wfMessage( 'flexform-fileupload-no-target' )->text(), 0 );
+		}
+
+		$pageContent = ( $options->pageContent === false ) ? '' : $options->pageContent;
+
+		$pageContentPrefix = ( $options->pageContentPrefix === false )
+			? ''
+			: ContentCore::parseTitle( $options->pageContentPrefix, true );
+
+		$pageContentSuffix = ( $options->pageContentSuffix === false )
+			? ''
+			: ContentCore::parseTitle( $options->pageContentSuffix, true );
+
+		$imageComment = ( $options->imageComment === false ) ? $this->getSummary() : $options->imageComment;
+
+		$convert = ( $options->imageForce === false || $options->imageForce === '' ) ? false : $options->imageForce;
+
+		$upload_dir = rtrim( Config::getConfigVariable( 'file_temp_path' ), '/' ) . '/';
+
+		/*
 		$target        = General::getJsonValue(
 			'wsform_file_target',
 			$fileDetails
@@ -230,6 +310,7 @@ class Upload {
 			'wsform_action',
 			$fileDetails
 		);
+		*/
 		$fileActionConvertDetails = null;
 		if ( $fileAction !== false ) {
 			if (
@@ -560,202 +641,50 @@ class Upload {
 				switch ( $fileAction ) {
 				case "xls":
 				case "xlsx":
-					$convert = new SpreadsheetConverter();
-					$convert->setReader( $fileAction );
-					$convert->setFileName( $storedFile );
-					$convert->setSheetByName( $excelSheetByName );
-					$convert->setSheetById( $excelSheetById );
-					$json = $convert->convertFile();
-					// Now create the page in the wiki
-					if ( !Config::isDebug() ) {
-						$save = new Save();
-						try {
-							$save->saveToWiki(
-								$titleName,
-								[ $fileSlot => $json ],
-								$imageComment
-							);
-						} catch ( FlexFormException $e ) {
-							throw new FlexFormException(
-								$e->getMessage(),
-								0,
-								$e
-							);
-						}
-					}
+					$spreadsheetHandler = new SpreadsheetUploadHandler();
+					$spreadsheetHandler->process(
+						$fileAction,
+						$storedFile,
+						$titleName,
+						$fileDetails,
+						$imageComment
+					);
 					break;
 				case "convert":
-					// We need to do a Pandoc conversion
-					//echo "<pre>";
-					//var_dump( $fileActionConvertDetails );
-					//die();
-					$convert = new PandocConverter();
-					$convert->setConvertFrom( $fileActionConvertDetails['convertfrom'] );
-					$convert->setConvertTo( $fileActionConvertDetails['convertto'] );
-					$convert->setAdditionalArguments( $fileActionConvertDetails['additional-arguments'] );
-					$convert->setFileName(
-						$filesCore->parseTarget( $storedFile, $fileActionConvertDetails['uploadoriginalas'] )
-					);
-					$newContent = $convert->convertFile();
-					Debug::addToDebug(
-						'File converted with Pandoc: ' . $titleName,
-						[
-							'$pageContentPrefix'    => $pageContentPrefix,
-							'$newContent' => $newContent,
-							'$pageContentSuffix'  => $pageContentSuffix
-						]
-					);
-					// If the target is not binary, we can create the page and upload attached files
-					if ( !$convert->isBinaryTarget() ) {
-						$newContent = $pageContentPrefix . $newContent . $pageContentSuffix;
-						$possibleImagesInDocument = $convert->getPossibleImagesFromConversion();
-						if ( $possibleImagesInDocument !== false ) {
-							$fCount = 1;
-							foreach ( $possibleImagesInDocument as $singleImage ) {
-								// find [filename] and replace
-								$newFname = $titleName . '-' . basename( $singleImage );
-								if ( Config::isDebug() ) {
-									Debug::addToDebug(
-										$fCount . ' - Preparing to upload image file from document: ' . $fCount,
-										[
-											'$newFname' => $newFname,
-											'$singleImage' => $singleImage,
-											'stored file' => $storedFile,
-											'details' => $details,
-											'comment' => $imageComment
-										]
-									);
-								}
-								if ( !Config::isDebug() ) {
-									$resultFileUpload = $this->uploadFileToWiki(
-										$singleImage,
-										$newFname,
-										$thisUser,
-										$details,
-										$imageComment,
-										wfTimestampNow()
-									);
-									if ( $resultFileUpload !== true ) {
-										throw new FlexFormException(
-											$resultFileUpload, 0
-										);
-									}
-								}
-								$search = $convert->pandocGetSearchFor() . basename( $singleImage );
-								$replace = $convert->pandocGetReplaceWith( $newFname );
-								$newContent = str_replace(
-									$search,
-									$replace,
-									$newContent
-								);
-								unlink( $singleImage );
-								$fCount++;
-							}
-						}
-					} else {
-						// If the target is binary, then simply upload it
-						$titleName .= "." . $fileNameExtension;
+					$pandocHandler = new PandocUploadHandler( $this, $filesCore );
 
-						$resultFileUpload = $this->uploadFileToWiki(
-							$upload_dir . $storedFile,
-							$titleName,
-							$thisUser,
-							$details,
-							$imageComment,
-							wfTimestampNow()
-						);
-						if ( $resultFileUpload !== true ) {
-							throw new FlexFormException(
-								$resultFileUpload, 0
-							);
-						}
-					}
-					// Now create the page in the wiki
-
-					if ( !$convert->isBinaryTarget() ) {
-						$save = new Save();
-						try {
-							$save->saveToWiki(
-								$titleName,
-								[ $fileSlot => $newContent ],
-								$imageComment
-							);
-						} catch ( FlexFormException $e ) {
-							throw new FlexFormException(
-								$e->getMessage(), 0, $e
-							);
-						}
-					}
-					if ( $fileActionConvertDetails['uploadoriginalas'] !== "false" ) {
-						// Check if [filename] should be replaced
-						$uploadOriginalAs = $filesCore->parseTarget(
-							$fileActionConvertDetails['uploadoriginalas'],
-							$targetFile,
-						);
-						Debug::addToDebug( 'Pandoc Upload Original - parse [filename]',
-							[
-								'targetfile' => $targetFile,
-								'uploadoriginalas original' => $fileActionConvertDetails['uploadoriginalas'],
-								'after [filename] in targetfile parse' => $uploadOriginalAs
-							] );
-						$isOriginalTargetAFile = $this->isFileNameSpace( $titleName );
-						$pTitleName = $this->checkTitleForTarget(
-							$titleName,
-							$uploadOriginalAs
-						);
-						Debug::addToDebug( 'Pandoc Upload Original - parse [target]',
-						[
-							'titleName' => $titleName,
-							'after [filename] in targetfile parse' => $uploadOriginalAs,
-							'after [target] in titlename parse' => $pTitleName,
-						]
-						);
-						if ( $fileActionConvertDetails['original-file-content'] !== "false" ) {
-							$details = $fileActionConvertDetails['original-file-content'];
-						}
-						if (
-							$isOriginalTargetAFile
-							&& empty( $details )
-						) {
-							Debug::addToDebug( 'Pandoc Upload Original - same title',
-								'Converted title same as uploadoriginal title' .
-								'content is for main slot, so adding to file-upload'
-							);
-							$details = $newContent;
-						}
-						$resultFileUpload = $this->uploadFileToWiki(
-						$upload_dir . $storedFile,
-						$pTitleName,
-						$thisUser,
+					$pandocHandler->process(
+						$fileActionConvertDetails,
+						$storedFile,
+						$targetFile,
+						$titleName,
+						$fileNameExtension,
+						$pageContentPrefix,
+						$pageContentSuffix,
+						$fileSlot,
 						$details,
 						$imageComment,
-						wfTimestampNow()
-						);
-						if ( $resultFileUpload !== true ) {
-							throw new FlexFormException(
-								$resultFileUpload, 0
-							);
-						}
-					}
+						$thisUser,
+						$upload_dir
+					);
 				break;
 				}
 			} else {
-				if ( !Config::isDebug() ) {
-					$resultFileUpload = $this->uploadFileToWiki(
-						$upload_dir . $storedFile,
-						$titleName,
-						$thisUser,
-						$details,
-						$imageComment,
-						wfTimestampNow()
+				$resultFileUpload = $this->uploadFileToWiki(
+					$upload_dir . $storedFile,
+					$titleName,
+					$thisUser,
+					$details,
+					$imageComment,
+					wfTimestampNow()
+				);
+				if ( $resultFileUpload !== true ) {
+					throw new FlexFormException(
+						$resultFileUpload,
+						0
 					);
-					if ( $resultFileUpload !== true ) {
-						throw new FlexFormException(
-							$resultFileUpload,
-							0
-						);
-					}
 				}
+
 			}
 			unlink( $upload_dir . $storedFile );
 		}
@@ -854,8 +783,8 @@ class Upload {
 	 *
 	 * @return bool|string
 	 * @throws FlexFormException
-	 * @throws \MWContentSerializationException
-	 * @throws \MWException
+	 * @throws MWContentSerializationException
+	 * @throws Exception
 	 */
 	public function uploadFileToWiki(
 		string $filePath,

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -686,14 +686,36 @@ class Upload {
 						if ( $fileActionConvertDetails['uploadoriginalas'] !== "false" ) {
 							// Check if [filename] should be replaced
 							$uploadOriginalAs = $filesCore->parseTarget(
+								$fileActionConvertDetails['uploadoriginalas'],
 								$targetFile,
-								$fileActionConvertDetails['uploadoriginalas']
 							);
+							Debug::addToDebug( 'Pandoc Upload Original - parse [filename]',
+								[
+									'targetfile' => $targetFile,
+									'uploadoriginalas original' => $fileActionConvertDetails['uploadoriginalas'],
+									'after [filename] in targetfile parse' => $uploadOriginalAs
+								]);
 							$pTitleName = $this->checkTitleForTarget(
 								$titleName,
 								$uploadOriginalAs
 							);
-
+							Debug::addToDebug( 'Pandoc Upload Original - parse [target]',
+							[
+								'titleName' => $titleName,
+								'after [filename] in targetfile parse' => $uploadOriginalAs,
+								'after [target] in titlename parse' => $pTitleName,
+							]
+							);
+							if (
+								$this->isFileNameSpace( $pTitleName )
+								&& empty( $details )
+							) {
+								Debug::addToDebug( 'Pandoc Upload Original - same title',
+									'Converted title same as uploadoriginal title',
+									'content is for main slot, so adding to file-upload'
+								);
+								$details = [ $fileSlot => $newContent ];
+							}
 							$resultFileUpload = $this->uploadFileToWiki(
 							$upload_dir . $storedFile,
 							$pTitleName,
@@ -712,7 +734,7 @@ class Upload {
 					break;
 				}
 			} else {
-				if ( ! Config::isDebug() ) {
+				if ( !Config::isDebug() ) {
 					$resultFileUpload = $this->uploadFileToWiki(
 						$upload_dir . $storedFile,
 						$titleName,
@@ -754,12 +776,25 @@ class Upload {
 	}
 
 	/**
-	 * @param string $pageTargetName
-	 * @param $target
+	 * @param string $title
 	 *
 	 * @return bool
 	 */
-	private function checkTitleForTarget( string $pageTargetName, $target ): bool {
+	private function isFileNameSpace( string $title ): bool {
+		$titleObject = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $title );
+		if ( $titleObject !== null && $titleObject->getNamespace() === NS_FILE ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * @param string $pageTargetName
+	 * @param string $target
+	 *
+	 * @return string
+	 */
+	private function checkTitleForTarget( string $pageTargetName, string $target ): string {
 		$target = str_replace( '[target]', $pageTargetName, $target );
 		if ( str_starts_with( $target, 'File:', ) || str_starts_with( $target, 'file:', ) ) {
 			$target = str_replace( [ 'File:', 'file:' ], '', $target );
@@ -774,6 +809,10 @@ class Upload {
 	 * @return string
 	 */
 	private function finalNameCleanUp( string $name, array $extensions ) : string {
+		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $name );
+		if ( $title !== null && $title->getNamespace() === NS_FILE ) {
+			return $name;
+		}
 		if ( Config::isDebug() ) {
 			Debug::addToDebug(
 				'finalNameCleanup',

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -23,9 +23,11 @@ use FlexForm\Processors\Utilities\General;
 use MediaHandler;
 use MWContentSerializationException;
 use MWFileProps;
+use RequestContext;
 use Title;
 use User;
 use MediaWiki\MediaWikiServices;
+use UtfNormal\Validator;
 
 class Upload {
 
@@ -74,13 +76,12 @@ class Upload {
 		return $this->fileDetails;
 	}
 
-
 	/**
 	 * Validates the file action and extracts Pandoc convert details if applicable.
 	 *
 	 * @param mixed $fileAction
 	 *
-	 * @return array{0: string|bool, 1: array|null} Returns the finalized action and convert details.
+	 * @return array {0: string|bool, 1: array|null} Returns the finalized action and convert details.
 	 * @throws FlexFormException
 	 */
 	private function parseFileAction( mixed $fileAction ): array {
@@ -209,7 +210,7 @@ class Upload {
 	 * @return bool
 	 * @throws FlexFormException
 	 * @throws MWContentSerializationException
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	public function fileUpload(): bool {
 		/**
@@ -228,7 +229,7 @@ class Upload {
 		 * ];
 		 */
 
-		$thisUser = \RequestContext::getMain()->getUser();
+		$thisUser = RequestContext::getMain()->getUser();
 		$processedFiles = [];
 
 		$fileName = $this->getFileName();
@@ -268,7 +269,6 @@ class Upload {
 			Debug::addToDebug( 'Number of files to process', $nrOfFiles );
 		}
 
-		$errors = [];
 		$filesCore = new FilesCore();
 
 		if ( $target === false || $target === '' ) {
@@ -304,8 +304,6 @@ class Upload {
 		}
 
 		$upload_dir = rtrim( Config::getConfigVariable( 'file_temp_path' ), '/' ) . '/';
-
-		$filesCore = new FilesCore();
 
 		for ( $i = 0; $i < $nrOfFiles; $i++ ) {
 			if ( Config::isDebug() ) {
@@ -603,38 +601,6 @@ class Upload {
 	}
 
 	/**
-	 * @param string $title
-	 *
-	 * @return bool
-	 */
-	private function isFileNameSpace( string $title ): bool {
-		$titleObject = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $title );
-		if ( $titleObject !== null && $titleObject->getNamespace() === NS_FILE ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
-	 * @param string $pageTargetName
-	 * @param string $target
-	 *
-	 * @return string
-	 */
-	private function checkTitleForTarget( string $pageTargetName, string $target ): string {
-		$target = str_replace( '[target]', $pageTargetName, $target );
-		if ( $this->isFileNameSpace( $target ) ) {
-			$titleObject = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $target );
-			if ( $titleObject !== null ) {
-				$target = $titleObject->getBaseText();
-			}
-		}
-
-		return $target;
-	}
-
-	/**
 	 * @param string $name
 	 * @param array $extensions
 	 *
@@ -673,12 +639,11 @@ class Upload {
 	 * @param User $user
 	 * @param string $content
 	 * @param string $summary
-	 * @param $timestamp
+	 * @param string $timestamp
 	 *
-	 * @return bool|string
+	 * @return true
 	 * @throws FlexFormException
 	 * @throws MWContentSerializationException
-	 * @throws Exception
 	 */
 	public function uploadFileToWiki(
 		string $filePath,
@@ -686,7 +651,7 @@ class Upload {
 		User $user,
 		string $content,
 		string $summary,
-		$timestamp
+		string $timestamp
 	) {
 		if ( !file_exists( $filePath ) ) {
 			throw new FlexFormException(
@@ -703,7 +668,7 @@ class Upload {
 			);
 		}
 
-		$base = \UtfNormal\Validator::cleanUp( wfBaseName( $filename ) );
+		$base = Validator::cleanUp( wfBaseName( $filename ) );
 		# Validate a title
 		$title = Title::makeTitleSafe(
 			NS_FILE,
@@ -792,111 +757,5 @@ class Upload {
 		}
 
 		return true;
-	}
-
-	/**
-	 * When a file is uploaded using the Slim extension, this function will take care of the saving
-	 *
-	 * @param $api
-	 *
-	 * @return array|bool Either true on success or a createMsg() error
-	 */
-	public function fileUploadSlim( $api ) {
-		global $IP;
-		$messages = new wbHandleResponses( false );
-		if ( !isset( $_POST['wsform_file_target'] ) || $_POST['wsform_file_target'] == "" ) {
-			return $messages->createMsg( 'No target file.' );
-		}
-
-		if ( !isset( $_POST['wsform_page_content'] ) || $_POST['wsform_page_content'] == "" ) {
-			return $messages->createMsg( 'No wiki content for this file.' );
-		}
-
-		if ( isset( $_POST['wsform_file_thumb_width'] ) && $_POST['wsform_file_thumb_width'] !== "" ) {
-			$thumbWidth = $_POST['wsform_file_thumb_width'];
-		} else {
-			$thumbWidth = false;
-		}
-
-		if (
-			isset( $_POST['wsform_file_thumb_height'] ) &&
-			$_POST['wsform_file_thumb_height'] !== "" &&
-			$thumbWidth !== false
-		) {
-			$thumbHeight = $_POST['wsform_file_thumb_height'];
-		} else {
-			$thumbHeight = null;
-		}
-
-		$upload_dir = $IP . "/extensions/FlexForm/uploads/";
-
-		include_once( $IP . '/extensions/FlexForm/modules/slim/server/slim.php' );
-		// Get posted data
-		$images = Slim::getImages( 'wsformfile_slim' );
-
-		// No image found under the supplied input name
-		if ( $images == false ) {
-			// inject your own auto crop or fallback script here
-			return $messages->createMsg(
-				'Presentor Slim was not used to upload these images.',
-				"ok"
-			);
-		}
-		if ( isset( $images[0]['output']['data'] ) ) {
-			// Save the file
-			$name = $images[0]['output']['name'];
-			$name = $targetFile = wsUtilities::makeUnderscoreFromSpace( $name );
-
-			// We'll use the output crop data
-			$data = $images[0]['output']['data'];
-
-			$output = Slim::saveFile(
-				$data,
-				$name,
-				$upload_dir,
-				false
-			);
-			if ( $api->getStatus() === false ) {
-				return $messages->createMsg( $api->getStatus( true ) );
-			}
-			$url = $api->app['baseURL'] . 'extensions/FlexForm/uploads/' . $output['name'];
-			$api->logMeIn();
-			$pname = trim( $_POST['wsform_file_target'] );
-			$details = trim( $_POST['wsform_page_content'] );
-			$comment = "Uploaded using FlexForm.";
-			$result = $api->uploadFileToWiki(
-				$pname,
-				$url,
-				$details,
-				$comment,
-				$upload_dir . $output['name']
-			);
-			if ( $thumbWidth !== false ) {
-				$thumbName = 'sm_' . $name;
-				$turl = $api->app['baseURL'] . 'extensions/FlexForm/uploads/' . $thumbName;
-				if (
-					createThumbnail(
-						$upload_dir . $name,
-						$upload_dir . $thumbName,
-						$thumbWidth,
-						$thumbHeight
-					)
-				) {
-					$result = $api->uploadFileToWiki(
-						'sm_' . $pname,
-						$turl,
-						$details,
-						$comment,
-						$upload_dir . $thumbName
-					);
-					unlink( $upload_dir . $thumbName );
-				}
-			}
-			unlink( $upload_dir . $output['name'] );
-
-			return true;
-		} else {
-			return $messages->createMsg( "Presentor Slim said : No image output." );
-		}
 	}
 }

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -62,15 +62,45 @@ class Upload {
 	/**
 	 * @return string
 	 */
-	private function getFileName() {
+	private function getFileName(): string {
 		return $this->fileName;
 	}
 
 	/**
 	 * @return array
 	 */
-	private function getFileDetails() {
+	private function getFileDetails(): array {
 		return $this->fileDetails;
+	}
+
+	/**
+	 * @param string $action
+	 *
+	 * @return string[]|null
+	 */
+	private function decodeAction( string $action ): ?array {
+		$fileActions = [
+			'convertfrom' => null,
+			'convertto' => 'mediawiki',
+			'uploadoriginalas' => "false" ];
+
+		if ( str_contains( $action, '|' ) ) {
+			$explodedAction = explode( '|', $action );
+		} else {
+			$explodedAction = [ $action ];
+		}
+		foreach ( $explodedAction as $singleAction ) {
+			if ( str_contains( $singleAction, ':' ) ) {
+				$explodedSingeAction = explode( ':', $singleAction );
+				if ( array_key_exists( $explodedSingeAction[0], $fileActions ) ) {
+					$fileActions[ $explodedSingeAction[0] ] = $explodedSingeAction[1];
+				}
+			}
+		}
+		if ( $fileActions['convertfrom'] === null ) {
+			return null;
+		}
+		return $fileActions;
 	}
 
 	/**
@@ -149,18 +179,20 @@ class Upload {
 			'wsform_action',
 			$fileDetails
 		);
-
-		if ( $fileAction === false ) {
-			$fileAction = false;
-		} else {
-			if ( strtolower( $fileAction ) !== 'upload' && strpos( strtolower( $fileAction ), 'convertfrom:' ) === false ) {
+		$fileActionConvertDetails = null;
+		if ( $fileAction !== false ) {
+			$fileAction = ContentCore::parseTitle( $fileAction, true );
+			if ( strtolower( $fileAction ) !== 'upload' && !str_contains( strtolower( $fileAction ), 'convertfrom:' ) ) {
 				throw new FlexFormException(
 					'Unknown upload action',
 					0
 				);
 			}
-			if ( strpos( strtolower( $fileAction ), 'convertfrom:' ) !== false ) {
-				$fileAction = trim( str_replace( 'convertfrom:', '', strtolower( $fileAction ) ) );
+			if ( str_contains( strtolower( $fileAction ), 'convertfrom:' ) ) {
+				// $fileAction = trim( str_replace( 'convertfrom:', '', strtolower( $fileAction ) ) );
+
+				$fileActionConvertDetails = $this->decodeAction( $fileAction );
+				$fileAction = 'convert';
 			}
 		}
 
@@ -236,6 +268,7 @@ class Upload {
 					'File #' . $i,
 					[
 						"fileaction"  => $fileAction,
+						"fileActionConvertDetails"  => $fileActionConvertDetails,
 						'tmp_name'    => $fileToProcess['tmp_name'][$i],
 						'name'        => $fileToProcess['name'][$i],
 						'is_uploaded' => $uploaded,
@@ -485,10 +518,11 @@ class Upload {
 						}
 					}
 					break;
-				default:
+				case "convert":
 					// We need to do a Pandoc conversion
 					$convert = new PandocConverter();
-					$convert->setConvertFrom( $fileAction );
+					$convert->setConvertFrom( $fileActionConvertDetails['convertfrom'] );
+					$convert->setConvertTo( $fileActionConvertDetails['convertto'] );
 					$convert->setFileName( $storedFile );
 					$newContent = $convert->convertFile();
 					Debug::addToDebug(
@@ -551,7 +585,7 @@ class Upload {
 						try {
 							$save->saveToWiki(
 								$titleName,
-								[ 'main' => $newContent ],
+								[ $fileSlot => $newContent ],
 								$imageComment
 							);
 						} catch ( FlexFormException $e ) {
@@ -560,6 +594,28 @@ class Upload {
 								0,
 								$e
 							);
+						}
+						if ( $fileActionConvertDetails['uploadoriginalas'] !== "false") {
+							$pTitleName = $filesCore->parseTarget(
+								$targetFile,
+								$fileActionConvertDetails['uploadoriginalas']
+							);
+							if ( ! Config::isDebug() ) {
+								$resultFileUpload = $this->uploadFileToWiki(
+									$upload_dir . $storedFile,
+									$pTitleName,
+									$thisUser,
+									$details,
+									$imageComment,
+									wfTimestampNow()
+								);
+								if ( $resultFileUpload !== true ) {
+									throw new FlexFormException(
+										$resultFileUpload,
+										0
+									);
+								}
+							}
 						}
 					}
 					break;
@@ -581,9 +637,10 @@ class Upload {
 						);
 					}
 				}
-				unlink( $upload_dir . $storedFile );
 			}
+			unlink( $upload_dir . $storedFile );
 		}
+
 		$separator = ',';
 
 		$ffUploadedFile     = General::makeUnderscoreFromSpace( 'FFUploadedFile-UploadName-' . $fileName );
@@ -622,10 +679,7 @@ class Upload {
 			);
 		}
 		foreach ( $extensions as $extension ) {
-			if ( strpos(
-					 $name,
-					 '.' . $extension
-				 ) !== false ) {
+			if ( str_contains( $name, '.' . $extension ) ) {
 				$name = str_replace(
 					'.' . $extension,
 					'',

--- a/src/Processors/Files/Upload.php
+++ b/src/Processors/Files/Upload.php
@@ -42,7 +42,7 @@ class Upload {
 	/**
 	 * @return string
 	 */
-	private function getSummary() : string {
+	private function getSummary(): string {
 		$summary = General::getPostString( 'mwwikicomment' );
 		if ( $summary === false ) {
 			return "Uploaded using FlexForm.";
@@ -56,7 +56,7 @@ class Upload {
 	 * @param array $fileDetails
 	 */
 	public function __construct( string $fileName, array $fileDetails ) {
-		$this->fileName    = $fileName;
+		$this->fileName = $fileName;
 		$this->fileDetails = $fileDetails;
 	}
 
@@ -87,7 +87,10 @@ class Upload {
 		$fileActionConvertDetails = null;
 
 		if ( $fileAction === false ) {
-			return [ $fileAction, $fileActionConvertDetails ];
+			return [
+				$fileAction,
+				$fileActionConvertDetails
+			];
 		}
 
 		$actionLower = strtolower( $fileAction );
@@ -105,7 +108,7 @@ class Upload {
 				Debug::addToDebug(
 					'Pandoc convertfrom error',
 					[
-						'fileaction'               => $fileAction,
+						'fileaction' => $fileAction,
 						'fileActionConvertDetails' => null
 					]
 				);
@@ -113,7 +116,10 @@ class Upload {
 			}
 		}
 
-		return [ $fileAction, $fileActionConvertDetails ];
+		return [
+			$fileAction,
+			$fileActionConvertDetails
+		];
 	}
 
 	/**
@@ -140,7 +146,7 @@ class Upload {
 			if ( str_contains( $singleAction, ':' ) ) {
 				$explodedSingeAction = explode( ':', $singleAction );
 				if ( array_key_exists( $explodedSingeAction[0], $fileActions ) ) {
-					$fileActions[ $explodedSingeAction[0] ] = $explodedSingeAction[1];
+					$fileActions[$explodedSingeAction[0]] = $explodedSingeAction[1];
 				}
 			}
 		}
@@ -151,9 +157,9 @@ class Upload {
 			foreach ( $fileActions['additional-arguments'] as $singleAdditionalArgument ) {
 				if ( str_contains( $singleAdditionalArgument, '=' ) ) {
 					$explodedArgs = explode( '=', $singleAdditionalArgument );
-					$newArgs[ $explodedArgs[0] ] = $explodedArgs[1];
+					$newArgs[$explodedArgs[0]] = $explodedArgs[1];
 				} else {
-					$newArgs[ $singleAdditionalArgument ] = '';
+					$newArgs[$singleAdditionalArgument] = '';
 				}
 			}
 			$fileActions['additional-arguments'] = $newArgs;
@@ -166,13 +172,13 @@ class Upload {
 		);
 		if ( $checkConversions !== true ) {
 			throw new FlexFormException(
-				'Pandoc Error: ' . $checkConversions,
-				0
+				'Pandoc Error: ' . $checkConversions, 0
 			);
 		}
 		if ( $fileActions['convertfrom'] === null ) {
 			return null;
 		}
+
 		return $fileActions;
 	}
 
@@ -195,6 +201,7 @@ class Upload {
 				return "pandoc-allow-additional-arguments are not allowed.";
 			}
 		}
+
 		return true;
 	}
 
@@ -204,7 +211,7 @@ class Upload {
 	 * @throws MWContentSerializationException
 	 * @throws \MWException
 	 */
-	public function fileUpload() : bool {
+	public function fileUpload(): bool {
 		/**
 		 *    return [
 		 * 'files'        => $files,
@@ -222,19 +229,18 @@ class Upload {
 		 */
 
 		$thisUser = \RequestContext::getMain()->getUser();
-
 		$processedFiles = [];
 
-		$fileName    = $this->getFileName();
+		$fileName = $this->getFileName();
 		$fileDetails = $this->getFileDetails();
 
 		if ( Config::isDebug() ) {
 			Debug::addToDebug(
 				'File upload start',
 				[
-					'field'       => $fileName,
+					'field' => $fileName,
 					'fileDetails' => $fileDetails,
-					'post'        => $_POST
+					'post' => $_POST
 				]
 			);
 		}
@@ -243,120 +249,30 @@ class Upload {
 
 		$options = new FileUploadOptions( $fileDetails );
 
-		[ $fileAction, $fileActionConvertDetails ] = $this->parseFileAction( $options->fileAction );
+		$target = $options->target;
+		$pageContent = $options->pageContent;
+		$pageContentPrefix = $options->pageContentPrefix;
+		$pageContentSuffix = $options->pageContentSuffix;
+		$pageTemplate = $options->pageTemplate;
+		$parseContent = $options->parseContent;
+		$imageForce = $options->imageForce;
+		$imageComment = $options->imageComment;
+
+		[
+			$fileAction,
+			$fileActionConvertDetails
+		] = $this->parseFileAction( $options->fileAction );
 
 		$nrOfFiles = count( $fileToProcess['name'] );
 		if ( Config::isDebug() ) {
 			Debug::addToDebug( 'Number of files to process', $nrOfFiles );
 		}
 
-		$errors    = [];
+		$errors = [];
 		$filesCore = new FilesCore();
 
-		if ( $options->target === false || $options->target === '' ) {
-			throw new FlexFormException( wfMessage( 'flexform-fileupload-no-target' )->text(), 0 );
-		}
-
-		$pageContent = ( $options->pageContent === false ) ? '' : $options->pageContent;
-
-		$pageContentPrefix = ( $options->pageContentPrefix === false )
-			? ''
-			: ContentCore::parseTitle( $options->pageContentPrefix, true );
-
-		$pageContentSuffix = ( $options->pageContentSuffix === false )
-			? ''
-			: ContentCore::parseTitle( $options->pageContentSuffix, true );
-
-		$imageComment = ( $options->imageComment === false ) ? $this->getSummary() : $options->imageComment;
-
-		$convert = ( $options->imageForce === false || $options->imageForce === '' ) ? false : $options->imageForce;
-
-		$upload_dir = rtrim( Config::getConfigVariable( 'file_temp_path' ), '/' ) . '/';
-
-		/*
-		$target        = General::getJsonValue(
-			'wsform_file_target',
-			$fileDetails
-		);
-		$pageContent   = General::getJsonValue(
-			'wsform_page_content',
-			$fileDetails
-		);
-		$pageContentPrefix   = General::getJsonValue(
-			'wsform_pandoc_prefix',
-			$fileDetails
-		);
-		$pageContentSuffix   = General::getJsonValue(
-			'wsform_pandoc_suffix',
-			$fileDetails
-		);
-		$pageTemplate  = General::getJsonValue(
-			'wsform_file_template',
-			$fileDetails
-		);
-		$parseContent  = General::getJsonValue(
-			'wsform_parse_content',
-			$fileDetails
-		);
-		$imageForce    = General::getJsonValue(
-			'wsform_image_force',
-			$fileDetails
-		);
-		$imageComment  = General::getJsonValue(
-			'wsform-upload-comment',
-			$fileDetails
-		);
-		$fileAction    = General::getJsonValue(
-			'wsform_action',
-			$fileDetails
-		);
-		*/
-		$fileActionConvertDetails = null;
-		if ( $fileAction !== false ) {
-			if (
-				strtolower( $fileAction ) !== 'upload' &&
-				!str_contains( strtolower( $fileAction ), 'convertfrom:' )
-			) {
-				throw new FlexFormException(
-					'Unknown upload action', 0
-				);
-			}
-			if ( str_contains( strtolower( $fileAction ), 'convertfrom:' ) ) {
-				$fileActionConvertDetails = $this->decodeAction( $fileAction );
-				if ( $fileActionConvertDetails !== null ) {
-					$fileAction = 'convert';
-				} else {
-					Debug::addToDebug(
-						'Pandoc convertfrom error',
-						[
-							'fileaction'       => $fileAction,
-							'fileActionConvertDetails' => $fileActionConvertDetails
-						]
-					);
-					throw new FlexFormException(
-						'Pandoc convertfrom error. No convert-from found',
-						0
-					);
-
-				}
-
-			}
-		}
-
-		$nrOfFiles = count( $fileToProcess['name'] );
-		if ( Config::isDebug() ) {
-			Debug::addToDebug(
-				'Number of files to process',
-				$nrOfFiles
-			);
-		}
-		$errors    = [];
-		$filesCore = new FilesCore();
 		if ( $target === false || $target === '' ) {
-			throw new FlexFormException(
-				wfMessage( 'flexform-fileupload-no-target' )->text(),
-				0
-			);
+			throw new FlexFormException( wfMessage( 'flexform-fileupload-no-target' )->text(), 0 );
 		}
 
 		if ( $pageContent === false ) {
@@ -384,19 +300,12 @@ class Upload {
 		if ( $imageForce === false || $imageForce === '' ) {
 			$convert = false;
 		} else {
-			/*
-			if ( $filesCore->getFileExtension( $_FILES['wsformfile']['name'] ) == $_POST['wsform_image_force'] ) {
-				$convert = false;
-			} else {
-				$convert = $_POST['wsform_image_force'];
-			}
-			*/
 			$convert = $imageForce;
 		}
-		$upload_dir = rtrim(
-						  Config::getConfigVariable( 'file_temp_path' ),
-						  '/'
-					  ) . '/';
+
+		$upload_dir = rtrim( Config::getConfigVariable( 'file_temp_path' ), '/' ) . '/';
+
+		$filesCore = new FilesCore();
 
 		for ( $i = 0; $i < $nrOfFiles; $i++ ) {
 			if ( Config::isDebug() ) {
@@ -414,46 +323,46 @@ class Upload {
 				Debug::addToDebug(
 					'File #' . $i,
 					[
-						"fileaction"  => $fileAction,
-						"fileActionConvertDetails"  => $fileActionConvertDetails,
-						'tmp_name'    => $fileToProcess['tmp_name'][$i],
-						'name'        => $fileToProcess['name'][$i],
+						"fileaction" => $fileAction,
+						"fileActionConvertDetails" => $fileActionConvertDetails,
+						'tmp_name' => $fileToProcess['tmp_name'][$i],
+						'name' => $fileToProcess['name'][$i],
 						'is_uploaded' => $uploaded,
-						'exists'      => $exists,
-						'error'       => $fileToProcess['error'][$i]
+						'exists' => $exists,
+						'error' => $fileToProcess['error'][$i]
 					]
 				);
 			}
-			if ( !file_exists( $fileToProcess['tmp_name'][$i] ) || ! is_uploaded_file(
+			if (
+				!file_exists( $fileToProcess['tmp_name'][$i] ) || !is_uploaded_file(
 					$fileToProcess['tmp_name'][$i]
-				) ) {
+				)
+			) {
 				throw new FlexFormException(
 					wfMessage(
 						'flexform-fileupload-file-not-found',
 						$fileToProcess['name'][$i]
-					)->text(),
-					0
+					)->text(), 0
 				);
 			}
 			$filename = $fileToProcess['name'][$i];
-			$status   = $filesCore->checkFileForErrors( $fileToProcess['error'][$i] );
-			$tmpName  = $fileToProcess['tmp_name'][$i];
+			$status = $filesCore->checkFileForErrors( $fileToProcess['error'][$i] );
+			$tmpName = $fileToProcess['tmp_name'][$i];
 
 			if ( $status !== false ) {
 				throw new FlexFormException(
 					wfMessage(
 						'flexform-fileupload-file-errors',
 						$status
-					)->text(),
-					0
+					)->text(), 0
 				);
 			}
 
 			$targetFile = General::makeUnderscoreFromSpace( $filename );
 
-			$fileNameExtension         = $filesCore->getFileExtension( $filename );
+			$fileNameExtension = $filesCore->getFileExtension( $filename );
 			$originalFileNameExtension = $fileNameExtension;
-			$fileNameBase              = $filesCore->remove_extension_from_image( $targetFile );
+			$fileNameBase = $filesCore->remove_extension_from_image( $targetFile );
 
 			$fileNameBase = ContentCore::urlToSEO( $fileNameBase );
 
@@ -461,20 +370,22 @@ class Upload {
 				Debug::addToDebug(
 					'File #' . $i . ' passed error checks',
 					[
-						'targetFile'             => $targetFile,
-						'upload dir'             => $upload_dir,
-						'convert'                => $convert,
+						'targetFile' => $targetFile,
+						'upload dir' => $upload_dir,
+						'convert' => $convert,
 						'current file extension' => $fileNameExtension,
-						'current file basename'  => $fileNameBase
+						'current file basename' => $fileNameBase
 					]
 				);
 			}
 
 			$filesSupported = Definitions::getImageHandler();
-			$fileType       = exif_imagetype( $tmpName );
-			if ( $convert !== false && $filesCore->getFileExtension(
-					$filename
-				) !== $convert && isset( $filesSupported[$fileType] ) ) {
+			$fileType = exif_imagetype( $tmpName );
+			if (
+				$convert !== false &&
+				$filesCore->getFileExtension( $filename ) !== $convert &&
+				isset( $filesSupported[$fileType] )
+			) {
 				if ( Config::isDebug() ) {
 					Debug::addToDebug(
 						'Converting File #' . $i . ' to ' . $convert,
@@ -490,10 +401,7 @@ class Upload {
 					100
 				);
 				if ( Config::isDebug() ) {
-					Debug::addToDebug(
-						'NewFile for File #' . $i,
-						[ 'newFile' => $newFile ]
-					);
+					Debug::addToDebug( 'NewFile for File #' . $i, [ 'newFile' => $newFile ] );
 				}
 				if ( $newFile === false ) {
 					throw new FlexFormException(
@@ -503,21 +411,16 @@ class Upload {
 								$filename
 							),
 							$convert
-						)->text(),
-						0
+						)->text(), 0
 					);
 				}
 				$fileNameExtension = $filesCore->getFileExtension( $newFile );
 			} else {
-				if ( move_uploaded_file(
-					$tmpName,
-					$upload_dir . $targetFile
-				) ) {
+				if ( move_uploaded_file( $tmpName, $upload_dir . $targetFile ) ) {
 					$newFile = $targetFile;
 				} else {
 					throw new FlexFormException(
-						wfMessage( 'flexform-fileupload-file-move-error' )->text(),
-						0
+						wfMessage( 'flexform-fileupload-file-move-error' )->text(), 0
 					);
 				}
 			}
@@ -526,14 +429,13 @@ class Upload {
 			$storedFile = $newFile;
 			// Filename without extension
 			$titleName = $filesCore->remove_extension_from_image( $newFile );
+
 			if ( Config::getConfigVariable( 'create-seo-titles' ) === true ) {
 				$titleName = ContentCore::urlToSEO( $titleName );
 			}
+
 			// find [filename] and replace
-			$titleName = $filesCore->parseTarget(
-				trim( $target ),
-				$titleName
-			);
+			$titleName = $filesCore->parseTarget( trim( $target ), $titleName );
 
 			if ( $parseContent !== false ) {
 				$details = trim( $pageContent );
@@ -543,7 +445,7 @@ class Upload {
 
 			if ( $pageTemplate && $parseContent !== false ) {
 				$filePageTemplate = trim( $pageTemplate );
-				$details          = ContentCore::setFileTemplate(
+				$details = ContentCore::setFileTemplate(
 					$filePageTemplate,
 					$details
 				);
@@ -613,10 +515,10 @@ class Upload {
 					'Preparing to upload file #' . $i,
 					[
 						'original file name' => $filename,
-						'new file name'      => $titleName,
-						'stored file'        => $storedFile,
-						'details'            => $details,
-						'comment'            => $imageComment
+						'new file name' => $titleName,
+						'stored file' => $storedFile,
+						'details' => $details,
+						'comment' => $imageComment
 					]
 				);
 			}
@@ -626,48 +528,40 @@ class Upload {
 			$processedFiles[$fileName]['new-name'][] = $titleName;
 
 			if ( $fileAction !== false ) {
-				$excelSheetByName = General::getJsonValue( 'wsform_sheetbyname', $fileDetails );
-				$excelSheetById = General::getJsonValue( 'wsform_sheetbyid', $fileDetails );
-				if ( $excelSheetByName === false && $excelSheetById === false ) {
-					$excelSheetById = 0;
-				}
-				$fileSlot = General::getJsonValue(
-					'wsform_slot',
-					$fileDetails
-				);
+				$fileSlot = General::getJsonValue( 'wsform_slot', $fileDetails );
 				if ( $fileSlot === false ) {
 					$fileSlot = 'main';
 				}
 				switch ( $fileAction ) {
-				case "xls":
-				case "xlsx":
-					$spreadsheetHandler = new SpreadsheetUploadHandler();
-					$spreadsheetHandler->process(
-						$fileAction,
-						$storedFile,
-						$titleName,
-						$fileDetails,
-						$imageComment
-					);
-					break;
-				case "convert":
-					$pandocHandler = new PandocUploadHandler( $this, $filesCore );
+					case "xls":
+					case "xlsx":
+						$spreadsheetHandler = new SpreadsheetUploadHandler();
+						$spreadsheetHandler->process(
+							$fileAction,
+							$storedFile,
+							$titleName,
+							$fileDetails,
+							$imageComment
+						);
+						break;
+					case "convert":
+						$pandocHandler = new PandocUploadHandler( $this, $filesCore );
 
-					$pandocHandler->process(
-						$fileActionConvertDetails,
-						$storedFile,
-						$targetFile,
-						$titleName,
-						$fileNameExtension,
-						$pageContentPrefix,
-						$pageContentSuffix,
-						$fileSlot,
-						$details,
-						$imageComment,
-						$thisUser,
-						$upload_dir
-					);
-				break;
+						$pandocHandler->process(
+							$fileActionConvertDetails,
+							$storedFile,
+							$targetFile,
+							$titleName,
+							$fileNameExtension,
+							$pageContentPrefix,
+							$pageContentSuffix,
+							$fileSlot,
+							$details,
+							$imageComment,
+							$thisUser,
+							$upload_dir
+						);
+						break;
 				}
 			} else {
 				$resultFileUpload = $this->uploadFileToWiki(
@@ -680,20 +574,18 @@ class Upload {
 				);
 				if ( $resultFileUpload !== true ) {
 					throw new FlexFormException(
-						$resultFileUpload,
-						0
+						$resultFileUpload, 0
 					);
 				}
-
 			}
 			unlink( $upload_dir . $storedFile );
 		}
 
 		$separator = ',';
 
-		$ffUploadedFile     = General::makeUnderscoreFromSpace( 'FFUploadedFile-UploadName-' . $fileName );
+		$ffUploadedFile = General::makeUnderscoreFromSpace( 'FFUploadedFile-UploadName-' . $fileName );
 		$ffUploadedFileBase = General::makeUnderscoreFromSpace( 'FFUploadedFile-UploadBase-' . $fileName );
-		$ffUploadedFileNew  = General::makeUnderscoreFromSpace( 'FFUploadedFile-NewName-' . $fileName );
+		$ffUploadedFileNew = General::makeUnderscoreFromSpace( 'FFUploadedFile-NewName-' . $fileName );
 		$_POST[$ffUploadedFile] = implode(
 			$separator,
 			$processedFiles[$fileName]['upload-name']
@@ -720,6 +612,7 @@ class Upload {
 		if ( $titleObject !== null && $titleObject->getNamespace() === NS_FILE ) {
 			return true;
 		}
+
 		return false;
 	}
 
@@ -737,6 +630,7 @@ class Upload {
 				$target = $titleObject->getBaseText();
 			}
 		}
+
 		return $target;
 	}
 
@@ -746,7 +640,7 @@ class Upload {
 	 *
 	 * @return string
 	 */
-	private function finalNameCleanUp( string $name, array $extensions ) : string {
+	private function finalNameCleanUp( string $name, array $extensions ): string {
 		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $name );
 		if ( $title !== null && $title->getNamespace() === NS_FILE ) {
 			return $name;
@@ -755,7 +649,7 @@ class Upload {
 			Debug::addToDebug(
 				'finalNameCleanup',
 				[
-					'name'                 => $name,
+					'name' => $name,
 					'extensions to remove' => $extensions
 				]
 			);
@@ -794,20 +688,18 @@ class Upload {
 		string $summary,
 		$timestamp
 	) {
-		if ( ! file_exists( $filePath ) ) {
+		if ( !file_exists( $filePath ) ) {
 			throw new FlexFormException(
 				wfMessage(
 					'flexform-fileupload-file-not-found',
 					$filePath
-				)->text(),
-				0
+				)->text(), 0
 			);
 		}
 
 		if ( $user === false ) {
 			throw new FlexFormException(
-				wfMessage( 'flexform-fileupload-user-unknown' )->text(),
-				0
+				wfMessage( 'flexform-fileupload-user-unknown' )->text(), 0
 			);
 		}
 
@@ -817,26 +709,25 @@ class Upload {
 			NS_FILE,
 			$base
 		);
-		if ( ! is_object( $title ) ) {
+		if ( !is_object( $title ) ) {
 			throw new FlexFormException(
 				wfMessage(
 					'flexform-fileupload-user-unknown',
 					$base
-				)->text(),
-				0
+				)->text(), 0
 			);
 		}
 
-		$fileRepo       = MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo();
-		$image          = $fileRepo->newFile( $title );
-		$mwProps        = new MWFileProps( MediaWikiServices::getInstance()->getMimeAnalyzer() );
-		$props          = $mwProps->getPropsFromPath(
+		$fileRepo = MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo();
+		$image = $fileRepo->newFile( $title );
+		$mwProps = new MWFileProps( MediaWikiServices::getInstance()->getMimeAnalyzer() );
+		$props = $mwProps->getPropsFromPath(
 			$filePath,
 			true
 		);
-		$flags          = 0;
+		$flags = 0;
 		$publishOptions = [];
-		$handler        = MediaHandler::getHandler( $props['mime'] );
+		$handler = MediaHandler::getHandler( $props['mime'] );
 		if ( $handler ) {
 			$publishOptions['headers'] = $handler->getContentHeaders( $props['metadata'] );
 		} else {
@@ -848,14 +739,13 @@ class Upload {
 			$publishOptions
 		);
 
-		if ( ! $archive->isGood() ) {
+		if ( !$archive->isGood() ) {
 			throw new FlexFormException(
 				$archive->getWikiText(
 					false,
 					false,
 					'en'
-				),
-				0
+				), 0
 			);
 		}
 		$commentText = $content;
@@ -864,11 +754,11 @@ class Upload {
 				'Uploading ' . $filename,
 				[
 					'archive value' => $archive->value,
-					'summary'       => $summary,
-					'content'       => $content,
-					'props'         => $props,
-					'base'          => $base,
-					'commentText'   => $commentText
+					'summary' => $summary,
+					'content' => $content,
+					'props' => $props,
+					'base' => $base,
+					'commentText' => $commentText
 				]
 			);
 		}
@@ -914,11 +804,11 @@ class Upload {
 	public function fileUploadSlim( $api ) {
 		global $IP;
 		$messages = new wbHandleResponses( false );
-		if ( ! isset( $_POST['wsform_file_target'] ) || $_POST['wsform_file_target'] == "" ) {
+		if ( !isset( $_POST['wsform_file_target'] ) || $_POST['wsform_file_target'] == "" ) {
 			return $messages->createMsg( 'No target file.' );
 		}
 
-		if ( ! isset( $_POST['wsform_page_content'] ) || $_POST['wsform_page_content'] == "" ) {
+		if ( !isset( $_POST['wsform_page_content'] ) || $_POST['wsform_page_content'] == "" ) {
 			return $messages->createMsg( 'No wiki content for this file.' );
 		}
 
@@ -928,7 +818,11 @@ class Upload {
 			$thumbWidth = false;
 		}
 
-		if ( isset( $_POST['wsform_file_thumb_height'] ) && $_POST['wsform_file_thumb_height'] !== "" && $thumbWidth !== false ) {
+		if (
+			isset( $_POST['wsform_file_thumb_height'] ) &&
+			$_POST['wsform_file_thumb_height'] !== "" &&
+			$thumbWidth !== false
+		) {
 			$thumbHeight = $_POST['wsform_file_thumb_height'];
 		} else {
 			$thumbHeight = null;
@@ -967,10 +861,10 @@ class Upload {
 			}
 			$url = $api->app['baseURL'] . 'extensions/FlexForm/uploads/' . $output['name'];
 			$api->logMeIn();
-			$pname   = trim( $_POST['wsform_file_target'] );
+			$pname = trim( $_POST['wsform_file_target'] );
 			$details = trim( $_POST['wsform_page_content'] );
 			$comment = "Uploaded using FlexForm.";
-			$result  = $api->uploadFileToWiki(
+			$result = $api->uploadFileToWiki(
 				$pname,
 				$url,
 				$details,
@@ -979,13 +873,15 @@ class Upload {
 			);
 			if ( $thumbWidth !== false ) {
 				$thumbName = 'sm_' . $name;
-				$turl      = $api->app['baseURL'] . 'extensions/FlexForm/uploads/' . $thumbName;
-				if ( createThumbnail(
-					$upload_dir . $name,
-					$upload_dir . $thumbName,
-					$thumbWidth,
-					$thumbHeight
-				) ) {
+				$turl = $api->app['baseURL'] . 'extensions/FlexForm/uploads/' . $thumbName;
+				if (
+					createThumbnail(
+						$upload_dir . $name,
+						$upload_dir . $thumbName,
+						$thumbWidth,
+						$thumbHeight
+					)
+				) {
 					$result = $api->uploadFileToWiki(
 						'sm_' . $pname,
 						$turl,


### PR DESCRIPTION
This offers more Pandoc possibilities.

- convertfrom is now set in local settings using "**pandoc-convert-from**" 
- convertto is now set in local settings using "**pandoc-convert-to**"
- "**pandoc-allow-additional-arguments**" array of additional allowed parameters to a Pandoc conversion in local settings 
- Additonial conversion option is "**uploadoriginalas**", allowing to not only convert a document, but also upload it

Example:

```
<input type="file" id="docxUpload" name="docx" target="File:[filename].docx" pagecontent="" error_id="docxError" verbose_id="docxVerbose" required="required" 
  action="convertfrom:docx|uploadoriginalas:[target]|convertto:mediawiki|additional-arguments:lua-filter=[path]fix-headings.lua" 
```
