### PR TITLE
Add compatibility for SMW 7

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexForm",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "author": [
     "[https://www.wikibase-solutions.com/author/charlot Sen-Sai]"
   ],

--- a/src/Processors/Content/Save.php
+++ b/src/Processors/Content/Save.php
@@ -14,7 +14,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRecord;
 use MWContentSerializationException;
 use RequestContext;
-use SMW\Maintenance\MaintenanceFactory;
+use SMW\Services\ServicesFactory;
 use Title;
 use User;
 use WikiPage;
@@ -318,7 +318,8 @@ class Save {
 			$store->setOption( Store::OPT_CREATE_UPDATE_JOB,
 				false );
 
-			$rebuilder = ( new MaintenanceFactory() )->newDataRebuilder( $store );
+			$rebuilder = ServicesFactory::getInstance()->newMaintenanceFactory()
+				->newDataRebuilder( $store );
 
 			$rebuilder->setOptions( // Tell SMW to only rebuild the current page
 				new Options( [ 'page' => $title->getFullText() ] ) );

--- a/src/Processors/Content/Save.php
+++ b/src/Processors/Content/Save.php
@@ -14,8 +14,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRecord;
 use MWContentSerializationException;
 use RequestContext;
-use SMW\Maintenance\DataRebuilder;
-use SMW\Services\ServicesFactory;
+use SMW\Maintenance\MaintenanceFactory;
 use Title;
 use User;
 use WikiPage;
@@ -319,8 +318,7 @@ class Save {
 			$store->setOption( Store::OPT_CREATE_UPDATE_JOB,
 				false );
 
-			$rebuilder = new DataRebuilder( $store,
-				ServicesFactory::getInstance()->newTitleFactory() );
+			$rebuilder = ( new MaintenanceFactory() )->newDataRebuilder( $store );
 
 			$rebuilder->setOptions( // Tell SMW to only rebuild the current page
 				new Options( [ 'page' => $title->getFullText() ] ) );


### PR DESCRIPTION
Fixes form submissions on SMW 7, where ServicesFactory::newTitleFactory() was removed.
Uses SMW’s cross-version MaintenanceFactory instead, preserving compatibility with both SMW 6 and 7 on MediaWiki 1.43.

Info: I had a customer recently updated to SMW 7.2 and now almost all (if not all) flexform submissions fail because:
```
[exception] [357eed6dd20871e3da2307d7] /Speciaal:FlexForm
Error: Call to undefined method SMW\Services\ServicesFactory::newTitleFactory()

#16 /var/www/html/includes/exception/MWExceptionRenderer.php(190): MediaWiki\Output\OutputPage->output()
#17 /var/www/html/includes/exception/MWExceptionRenderer.php(109): MWExceptionRenderer::reportHTML(Error)
#18 /var/www/html/includes/exception/MWExceptionHandler.php(135): MWExceptionRenderer::output(Error, int)
#19 /var/www/html/includes/exception/MWExceptionHandler.php(239): MWExceptionHandler::report(Error)
#20 /var/www/html/includes/MediaWikiEntryPoint.php(222): MWExceptionHandler::handleException(Error, string)
#21 /var/www/html/includes/actions/ActionEntryPoint.php(83): MediaWiki\MediaWikiEntryPoint->handleTopLevelError(Error)
#22 /var/www/html/includes/MediaWikiEntryPoint.php(206): MediaWiki\Actions\ActionEntryPoint->handleTopLevelError(Error)
```