### PR TITLE
Support multiple emails per form

### DIFF
--- a/src/Processors/Content/ContentCore.php
+++ b/src/Processors/Content/ContentCore.php
@@ -523,17 +523,32 @@ class ContentCore {
 
 
 		if ( $email === "yes" ) {
-			$mail = new Mail();
-			// Handling template
-			if ( $mail->getTemplate() !== false ) {
-				try {
-					$mail->handleTemplate();
-				} catch ( FlexFormException $e ) {
-					throw new FlexFormException(
-						$e->getMessage(),
-						0,
-						$e
-					);
+			$mailConfigurations = General::getPostArray( 'mwmail' );
+			if ( $mailConfigurations === false ) {
+				$mailConfigurations = [ null ];
+			}
+			foreach ( $mailConfigurations as $mailConfiguration ) {
+				if ( $mailConfiguration !== null ) {
+					if ( !is_string( $mailConfiguration ) ) {
+						continue;
+					}
+					$mailConfiguration = json_decode( $mailConfiguration, true );
+					if ( !is_array( $mailConfiguration ) ) {
+						continue;
+					}
+				}
+				$mail = new Mail( false, $mailConfiguration );
+				// Handling template
+				if ( $mail->getTemplate() !== false ) {
+					try {
+						$mail->handleTemplate();
+					} catch ( FlexFormException $e ) {
+						throw new FlexFormException(
+							$e->getMessage(),
+							0,
+							$e
+						);
+					}
 				}
 			}
 		}

--- a/src/Processors/Content/Mail.php
+++ b/src/Processors/Content/Mail.php
@@ -63,9 +63,10 @@ class Mail {
 
 	/**
 	 * @param string|bool $template
+	 * @param array|null $mailFields
 	 */
-	public function __construct( $template = false ) {
-		$this->fields = Definitions::mailFields();
+	public function __construct( $template = false, ?array $mailFields = null ) {
+		$this->fields = Definitions::mailFields( $mailFields );
 		$this->template = $this->fields['mtemplate'];
 		if ( $template !== false ) {
 			$this->isBot = true;

--- a/src/Processors/Definitions.php
+++ b/src/Processors/Definitions.php
@@ -53,18 +53,19 @@ class Definitions {
 	/**
 	 * Return fields needed for sending emails
 	 *
+	 * @param array|null $postData optional post data to read from
 	 * @return array
 	 */
-	public static function mailFields() : array {
+	public static function mailFields( ?array $postData = null ) : array {
 		return [
-			'to'         => General::getPostString( 'mwmailto' ),
-			'content'    => General::getPostString( 'mwmailcontent' ),
-			'header'     => General::getPostString( 'mwmailheader' ),
-			'footer'     => General::getPostString( 'mwmailfooter' ),
-			'mtemplate'  => General::getPostString( 'mwmailtemplate' ),
-			'mjob'       => General::getPostString( 'mwmailjob' ),
-			'html'       => General::getPostString( 'mwmailhtml' ),
-			'attachment' => General::getPostString( 'mwmailattachment' ),
+			'to'         => General::getPostString( 'mwmailto', true, $postData ),
+			'content'    => General::getPostString( 'mwmailcontent', true, $postData ),
+			'header'     => General::getPostString( 'mwmailheader', true, $postData ),
+			'footer'     => General::getPostString( 'mwmailfooter', true, $postData ),
+			'mtemplate'  => General::getPostString( 'mwmailtemplate', true, $postData ),
+			'mjob'       => General::getPostString( 'mwmailjob', true, $postData ),
+			'html'       => General::getPostString( 'mwmailhtml', true, $postData ),
+			'attachment' => General::getPostString( 'mwmailattachment', true, $postData ),
 			'from'       => false,
 			'cc'         => false,
 			'bcc'        => false,
@@ -193,6 +194,7 @@ class Definitions {
 			"mwmailattachment",
 			"mwmailtemplate",
 			"mwmailjob",
+			"mwmail",
 			"mwcreatemultiple",
 			"mwonsuccess",
 			"mwdb",

--- a/src/Processors/Utilities/General.php
+++ b/src/Processors/Utilities/General.php
@@ -88,12 +88,14 @@ class General {
 	 *
 	 * @param string $var $_POST value to check
 	 * @param bool $clean to clean input
+	 * @param array|null $postData optional post data to read from
 	 *
 	 * @return bool|string  Returns false if not set or the value
 	 */
-	public static function getPostString( string $var, bool $clean = true ) {
-		if ( isset( $_POST[$var] ) && $_POST[$var] !== "" ) {
-			$template = $_POST[$var];
+	public static function getPostString( string $var, bool $clean = true, ?array $postData = null ) {
+		$postData ??= $_POST;
+		if ( isset( $postData[$var] ) && $postData[$var] !== "" ) {
+			$template = $postData[$var];
 		} else {
 			$template = false;
 		}

--- a/src/Render/Themes/Plain/PlainEmailRenderer.php
+++ b/src/Render/Themes/Plain/PlainEmailRenderer.php
@@ -9,15 +9,18 @@ class PlainEmailRenderer implements EmailRenderer {
 	 * @inheritDoc
 	 */
 	public function render_mail( array $mailArguments, string $base64content ) : string {
-		$template = "";
-
-		foreach ( $mailArguments as $name => $value ) {
-			$template .= sprintf(
-				'<input type="hidden" name="%s" value="%s">' . PHP_EOL,
-				htmlspecialchars( $name ),
-				htmlspecialchars( $value )
+		$template = '';
+		if ( isset( $mailArguments['mwparselast'] ) ) {
+			$template = sprintf(
+				'<input type="hidden" name="mwparselast" value="%s">' . PHP_EOL,
+				htmlspecialchars( $mailArguments['mwparselast'] )
 			);
+			unset( $mailArguments['mwparselast'] );
 		}
+		$template .= sprintf(
+			'<input type="hidden" name="mwmail[]" value="%s">' . PHP_EOL,
+			htmlspecialchars( json_encode( $mailArguments ) )
+		);
 
 		return $template;
 	}


### PR DESCRIPTION
Currently FlexForm does not support multiple `<_email>` tags in one form. The second email tag will simply overwrite the first one. I made this MR to support multiple emails. I need this in particular for my customer. 

Each `<_email>` is now stored as its own hidden mail package, so later email tags no longer overwrite earlier ones. When submitted, FlexForm opens those packages one by one and sends each email.

single email forms still work.

Tested on (and it works there):
https://csp-sandbox.wikibase.nl/Jimmy